### PR TITLE
Add simple configuration mechanism

### DIFF
--- a/manual/src/docs/asciidoc/chapters/02-basics.adoc
+++ b/manual/src/docs/asciidoc/chapters/02-basics.adoc
@@ -427,3 +427,17 @@ In that case, you might want to take advantage of the link:{javadoc-url}/core/or
 === Built-In `PathProviders`
 
 All built-in link:{javadoc-url}/core/org/approvej/approve/PathProvider.html[`PathProvider`] implementations are available via the link:{javadoc-url}/core/org/approvej/approve/PathProviders.html[`PathProviders`] utility class.
+
+
+== Configuration
+
+Optionally you can configure the default behaviors of ApproveJ by putting an `approvej.properties` file into your resource folder of your test suite (e.g. `src/test/resources/approvej.properties`).
+
+.Example `approvej.properties`
+----
+include::../../../test/resources/approvej.properties[]
+----
+
+Supported properties are:
+
+`defaultPrinter`:: the default printer class if none is specified via the `printWith` method (see <<printing>>)

--- a/manual/src/test/resources/approvej.properties
+++ b/manual/src/test/resources/approvej.properties
@@ -1,0 +1,1 @@
+defaultPrinter = org.approvej.print.ToStringPrinter

--- a/modules/core/src/main/java/org/approvej/ApprovalBuilder.java
+++ b/modules/core/src/main/java/org/approvej/ApprovalBuilder.java
@@ -1,5 +1,6 @@
 package org.approvej;
 
+import static org.approvej.Configuration.configuration;
 import static org.approvej.approve.Approvers.file;
 import static org.approvej.approve.Approvers.value;
 import static org.approvej.approve.PathProvider.DEFAULT_FILENAME_EXTENSION;
@@ -56,9 +57,6 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public class ApprovalBuilder<T> {
 
-  /** The default {@link Printer} used to print the value. */
-  public static final Printer<Object> DEFAULT_PRINTER = Object::toString;
-
   private T receivedValue;
   private final String filenameExtension;
 
@@ -113,7 +111,8 @@ public class ApprovalBuilder<T> {
   /**
    * Approves the {@link #receivedValue} by the given approver.
    *
-   * <p>If necessary the {@link #receivedValue} is printed using the {@link #DEFAULT_PRINTER}.
+   * <p>If necessary the {@link #receivedValue} is printed using the {@link
+   * Configuration#defaultPrinter()}.
    *
    * @param approver a {@link Consumer} or an {@link Approver} implementation
    * @throws ApprovalError if the approval fails
@@ -122,7 +121,7 @@ public class ApprovalBuilder<T> {
     if (receivedValue instanceof String printedValue) {
       approver.accept(printedValue);
     } else {
-      approver.accept(DEFAULT_PRINTER.apply(receivedValue));
+      approver.accept(configuration.defaultPrinter().apply(receivedValue));
     }
   }
 

--- a/modules/core/src/main/java/org/approvej/Configuration.java
+++ b/modules/core/src/main/java/org/approvej/Configuration.java
@@ -1,0 +1,52 @@
+package org.approvej;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import org.approvej.print.Printer;
+import org.approvej.print.ToStringPrinter;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Central configuration class for ApproveJ.
+ *
+ * <p>All properties have a default value, which can be overwritten in your
+ * src/test/resources/approvej.properties
+ *
+ * @param defaultPrinter the {@link Printer} that will be used if none is specified otherwise
+ */
+@NullMarked
+public record Configuration(Printer<Object> defaultPrinter) {
+
+  /** The loaded {@link Configuration} object. */
+  public static final Configuration configuration = loadConfiguration();
+
+  private static Configuration loadConfiguration() {
+    Properties properties = new Properties();
+    try (InputStream is =
+        Configuration.class.getClassLoader().getResourceAsStream("approvej.properties")) {
+      if (is != null) {
+        properties.load(is);
+
+        Printer<Object> printer = new ToStringPrinter();
+        try {
+          Class<?> defaultPrinterClass = Class.forName(properties.getProperty("defaultPrinter"));
+          if (Printer.class.isAssignableFrom(defaultPrinterClass)) {
+            // noinspection unchecked
+            printer = (Printer<Object>) defaultPrinterClass.getDeclaredConstructor().newInstance();
+          } else {
+            throw new ConfigurationError("Configured printer does not implement Printer<Object>");
+          }
+        } catch (ReflectiveOperationException e) {
+          throw new ConfigurationError("Failed to create printer", e);
+        }
+
+        return new Configuration(printer);
+      }
+    } catch (IOException e) {
+      throw new ConfigurationError("Failed to load configuration", e);
+    }
+
+    return new Configuration(new ToStringPrinter());
+  }
+}

--- a/modules/core/src/main/java/org/approvej/ConfigurationError.java
+++ b/modules/core/src/main/java/org/approvej/ConfigurationError.java
@@ -1,0 +1,24 @@
+package org.approvej;
+
+/** An error that occurs when there is an issue with loading the {@link Configuration}. */
+public class ConfigurationError extends RuntimeException {
+
+  /**
+   * Creates a new {@link ConfigurationError} with the given message and cause.
+   *
+   * @param message a message describing the error
+   * @param cause the cause of the error
+   */
+  public ConfigurationError(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  /**
+   * Creates a new {@link ConfigurationError} with the given message.
+   *
+   * @param message a message describing the error
+   */
+  public ConfigurationError(String message) {
+    super(message);
+  }
+}

--- a/modules/core/src/main/java/org/approvej/approve/TestMethod.java
+++ b/modules/core/src/main/java/org/approvej/approve/TestMethod.java
@@ -9,6 +9,16 @@ import java.util.Optional;
 import java.util.stream.Stream;
 import org.jspecify.annotations.NullMarked;
 
+/**
+ * Represents a test method in a test class. This interface provides a way to identify and work with
+ * test methods across different testing frameworks.
+ *
+ * <p>Implementations of this interface are provided for JUnit, TestNG, and Spock.
+ *
+ * @see JUnitTestMethod
+ * @see TestNGTestMethod
+ * @see SpockTestMethod
+ */
 @NullMarked
 public interface TestMethod {
 

--- a/modules/core/src/main/java/org/approvej/print/ToStringPrinter.java
+++ b/modules/core/src/main/java/org/approvej/print/ToStringPrinter.java
@@ -1,0 +1,13 @@
+package org.approvej.print;
+
+import org.jspecify.annotations.NullMarked;
+
+/** A simple {@link Printer} implementation that uses the {@link Object#toString()} method. */
+@NullMarked
+public class ToStringPrinter implements Printer<Object> {
+
+  @Override
+  public String apply(Object value) {
+    return value.toString();
+  }
+}

--- a/modules/core/src/main/java/org/approvej/print/ToStringPrinter.java
+++ b/modules/core/src/main/java/org/approvej/print/ToStringPrinter.java
@@ -1,13 +1,14 @@
 package org.approvej.print;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /** A simple {@link Printer} implementation that uses the {@link Object#toString()} method. */
 @NullMarked
 public class ToStringPrinter implements Printer<Object> {
 
   @Override
-  public String apply(Object value) {
-    return value.toString();
+  public String apply(@Nullable Object value) {
+    return "%s".formatted(value);
   }
 }

--- a/modules/core/src/test/java/org/approvej/ConfigurationTest.java
+++ b/modules/core/src/test/java/org/approvej/ConfigurationTest.java
@@ -1,0 +1,15 @@
+package org.approvej;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.approvej.print.ToStringPrinter;
+import org.junit.jupiter.api.Test;
+
+class ConfigurationTest {
+
+  @Test
+  void testLoadConfiguration() {
+    assertThat(Configuration.configuration).isNotNull();
+    assertThat(Configuration.configuration.defaultPrinter()).isInstanceOf(ToStringPrinter.class);
+  }
+}

--- a/modules/core/src/test/java/org/approvej/print/ToStringPrinterTest.java
+++ b/modules/core/src/test/java/org/approvej/print/ToStringPrinterTest.java
@@ -1,0 +1,17 @@
+package org.approvej.print;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ToStringPrinterTest {
+
+  @Test
+  void apply() {
+    ToStringPrinter printer = new ToStringPrinter();
+    assertThat(printer.apply("Hello")).isEqualTo("Hello");
+    assertThat(printer.apply(123)).isEqualTo("123");
+    assertThat(printer.apply(true)).isEqualTo("true");
+    assertThat(printer.apply(null)).isEqualTo("null");
+  }
+}

--- a/modules/core/src/test/resources/approvej.properties
+++ b/modules/core/src/test/resources/approvej.properties
@@ -1,0 +1,2 @@
+defaultPrinter = org.approvej.print.ToStringPrinter
+ignored = some value


### PR DESCRIPTION
As a first configuration value `defaultPrinter` should be added and replace the constant value in `ApprovalBuilder`.