### PR TITLE
Put post review re-approval into ApprovalBuilder

### DIFF
--- a/modules/core/src/main/java/org/approvej/ApprovalBuilder.java
+++ b/modules/core/src/main/java/org/approvej/ApprovalBuilder.java
@@ -169,9 +169,12 @@ public class ApprovalBuilder<T> {
    * @throws ApprovalError if the approval fails
    */
   public void byFile(PathProvider pathProvider) {
-    ApprovalResult result = file(pathProvider).apply(String.valueOf(receivedValue));
+    FileApprover approver = file(pathProvider);
+    ApprovalResult result = approver.apply(String.valueOf(receivedValue));
     if (result.needsApproval() && fileReviewer != null) {
-      result = fileReviewer.apply(pathProvider);
+      if (fileReviewer.apply(pathProvider).needsReapproval()) {
+        result = approver.apply(String.valueOf(receivedValue));
+      }
     }
     result.throwIfNotApproved();
   }

--- a/modules/core/src/main/java/org/approvej/ApprovalBuilder.java
+++ b/modules/core/src/main/java/org/approvej/ApprovalBuilder.java
@@ -16,6 +16,7 @@ import org.approvej.approve.PathProvider;
 import org.approvej.approve.PathProviderBuilder;
 import org.approvej.print.Printer;
 import org.approvej.review.FileReviewer;
+import org.approvej.review.ReviewResult;
 import org.approvej.scrub.Scrubber;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -170,13 +171,14 @@ public class ApprovalBuilder<T> {
    */
   public void byFile(PathProvider pathProvider) {
     FileApprover approver = file(pathProvider);
-    ApprovalResult result = approver.apply(String.valueOf(receivedValue));
-    if (result.needsApproval() && fileReviewer != null) {
-      if (fileReviewer.apply(pathProvider).needsReapproval()) {
-        result = approver.apply(String.valueOf(receivedValue));
+    ApprovalResult approvalResult = approver.apply(String.valueOf(receivedValue));
+    if (approvalResult.needsApproval() && fileReviewer != null) {
+      ReviewResult reviewResult = fileReviewer.apply(pathProvider);
+      if (reviewResult.needsReapproval()) {
+        approvalResult = approver.apply(String.valueOf(receivedValue));
       }
     }
-    result.throwIfNotApproved();
+    approvalResult.throwIfNotApproved();
   }
 
   /**

--- a/modules/core/src/main/java/org/approvej/ApprovalResult.java
+++ b/modules/core/src/main/java/org/approvej/ApprovalResult.java
@@ -1,6 +1,6 @@
 package org.approvej;
 
-/** Interface for results of approvals and reviews. */
+/** Interface for results of approvals. */
 public interface ApprovalResult {
 
   /**

--- a/modules/core/src/main/java/org/approvej/review/FileReviewResult.java
+++ b/modules/core/src/main/java/org/approvej/review/FileReviewResult.java
@@ -1,0 +1,3 @@
+package org.approvej.review;
+
+public record FileReviewResult(boolean needsReapproval) implements ReviewResult {}

--- a/modules/core/src/main/java/org/approvej/review/FileReviewer.java
+++ b/modules/core/src/main/java/org/approvej/review/FileReviewer.java
@@ -1,7 +1,6 @@
 package org.approvej.review;
 
 import java.util.function.Function;
-import org.approvej.ApprovalResult;
 import org.approvej.approve.PathProvider;
 
 /**
@@ -10,4 +9,4 @@ import org.approvej.approve.PathProvider;
  * <p>This usually means that a diff/merge tool is opened, which presents the difference between the
  * received and the previously approved value to users in case they differ.
  */
-public interface FileReviewer extends Function<PathProvider, ApprovalResult> {}
+public interface FileReviewer extends Function<PathProvider, ReviewResult> {}

--- a/modules/core/src/main/java/org/approvej/review/FileReviewerScript.java
+++ b/modules/core/src/main/java/org/approvej/review/FileReviewerScript.java
@@ -19,8 +19,8 @@ public record FileReviewerScript(String script) implements FileReviewer {
     try {
       String command =
           script
-              .replace(RECEIVED_PLACEHOLDER, "\"%s\"".formatted(pathProvider.receivedPath()))
-              .replace(APPROVED_PLACEHOLDER, "\"%s\"".formatted(pathProvider.approvedPath()));
+              .replace(RECEIVED_PLACEHOLDER, "%s".formatted(pathProvider.receivedPath()))
+              .replace(APPROVED_PLACEHOLDER, "%s".formatted(pathProvider.approvedPath()));
 
       Process process = new ProcessBuilder().command("sh", "-c", command).inheritIO().start();
       process.waitFor();

--- a/modules/core/src/main/java/org/approvej/review/FileReviewerScript.java
+++ b/modules/core/src/main/java/org/approvej/review/FileReviewerScript.java
@@ -1,10 +1,6 @@
 package org.approvej.review;
 
-import static java.nio.file.Files.readString;
-
 import java.io.IOException;
-import org.approvej.ApprovalResult;
-import org.approvej.approve.FileApprovalResult;
 import org.approvej.approve.PathProvider;
 
 /**
@@ -19,7 +15,7 @@ public record FileReviewerScript(String script) implements FileReviewer {
   private static final String APPROVED_PLACEHOLDER = "{approvedFile}";
 
   @Override
-  public ApprovalResult apply(PathProvider pathProvider) {
+  public ReviewResult apply(PathProvider pathProvider) {
     try {
       String command =
           script
@@ -29,10 +25,7 @@ public record FileReviewerScript(String script) implements FileReviewer {
       Process process = new ProcessBuilder().command("sh", "-c", command).inheritIO().start();
       process.waitFor();
 
-      return new FileApprovalResult(
-          readString(pathProvider.receivedPath()),
-          readString(pathProvider.approvedPath()),
-          pathProvider);
+      return new FileReviewResult(process.exitValue() == 0);
     } catch (IOException e) {
       throw new ReviewerError("Review by %s failed".formatted(getClass().getSimpleName()), e);
     } catch (InterruptedException e) {

--- a/modules/core/src/main/java/org/approvej/review/ReviewResult.java
+++ b/modules/core/src/main/java/org/approvej/review/ReviewResult.java
@@ -1,0 +1,14 @@
+package org.approvej.review;
+
+/** Interface for results of reviews. */
+public interface ReviewResult {
+
+  /**
+   * Determines if the approval should be reapplied.
+   *
+   * <p>Usually that means that approved value was changed during the review.
+   *
+   * @return true, if the approval should be reapplied
+   */
+  boolean needsReapproval();
+}

--- a/modules/core/src/test/java/org/approvej/ApprovalBuilderTest.java
+++ b/modules/core/src/test/java/org/approvej/ApprovalBuilderTest.java
@@ -1,7 +1,6 @@
 package org.approvej;
 
 import static java.nio.file.Files.copy;
-import static java.nio.file.Files.readString;
 import static java.nio.file.Files.writeString;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static java.time.format.DateTimeFormatter.ofPattern;
@@ -20,10 +19,11 @@ import java.nio.file.Path;
 import java.time.LocalDate;
 import java.util.UUID;
 import java.util.function.Function;
-import org.approvej.approve.FileApprovalResult;
 import org.approvej.approve.PathProvider;
 import org.approvej.approve.PathProviderBuilder;
+import org.approvej.review.FileReviewResult;
 import org.approvej.review.FileReviewer;
+import org.approvej.review.ReviewResult;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -184,13 +184,10 @@ class ApprovalBuilderTest {
   static class AutoAcceptFileReviewer implements FileReviewer {
 
     @Override
-    public ApprovalResult apply(PathProvider pathProvider) {
+    public ReviewResult apply(PathProvider pathProvider) {
       try {
         copy(pathProvider.receivedPath(), pathProvider.approvedPath(), REPLACE_EXISTING);
-        return new FileApprovalResult(
-            readString(pathProvider.approvedPath()).trim(),
-            readString(pathProvider.receivedPath()).trim(),
-            pathProvider);
+        return new FileReviewResult(true);
       } catch (IOException e) {
         throw new RuntimeException(e);
       }

--- a/modules/core/src/test/java/org/approvej/review/FileReviewerScriptTest.java
+++ b/modules/core/src/test/java/org/approvej/review/FileReviewerScriptTest.java
@@ -16,7 +16,7 @@ class FileReviewerScriptTest {
   @TempDir private Path tempDir;
 
   @Test
-  void accept() throws IOException {
+  void apply() throws IOException {
     FileReviewerScript reviewer = new FileReviewerScript("diff {receivedFile} {approvedFile}");
     PathProvider pathProvider = approvedPath(tempDir.resolve("apply-approved.txt"));
     writeString(pathProvider.approvedPath(), "Some approved text", StandardOpenOption.CREATE);


### PR DESCRIPTION
If the review caused a change in the approved file, the re-approval should happen within the ApprovalBuilder, not in the FileReviewer.