### PR TITLE
Allow to set a name for an approval

### DIFF
--- a/manual/src/docs/asciidoc/chapters/02-basics.adoc
+++ b/manual/src/docs/asciidoc/chapters/02-basics.adoc
@@ -81,6 +81,30 @@ include::../../../test/java/examples/java/BasicsDocTest-approve_pojos-approved.t
 See <<printing>> if need a more sophisticated way of printing.
 
 
+[id=naming]
+== Naming Approvals
+
+Optionally, you can assign a specific name for an approval.
+When you <<_approve_by_file>> the chosen name will be added to the filename to help identify the specific approval.
+It is also necessary to assign a name if there are multiple approvals per test case, as otherwise later approvals will overwrite earlier ones.
+
+[source,java,indent=0,role="primary"]
+.Java
+----
+include::../../../test/java/examples/java/BasicsDocTest.java[tag=approve_name]
+----
+[source,kotlin,indent=0,role="secondary"]
+.Kotlin
+----
+include::../../../test/kotlin/examples/kotlin/BasicsDocTest.kt[tag=approve_name]
+----
+
+This test generates two sets of files
+
+1. <TestClass>-<testMethod>-*jane*-<received/approved>.txt
+2. <TestClass>-<testMethod>-*john*-<received/approved>.txt
+
+
 [id="printing"]
 == Printing -- customize how values are turned into Strings
 

--- a/manual/src/test/java/examples/java/BasicsDocTest-approve_name-john-approved.txt
+++ b/manual/src/test/java/examples/java/BasicsDocTest-approve_name-john-approved.txt
@@ -1,0 +1,1 @@
+Person[name=John Doe, birthDate=1990-01-01]

--- a/manual/src/test/java/examples/java/BasicsDocTest.java
+++ b/manual/src/test/java/examples/java/BasicsDocTest.java
@@ -43,6 +43,15 @@ class BasicsDocTest {
   }
 
   @Test
+  void approve_name() {
+    // tag::approve_name[]
+    Person person = createPerson("John Doe", LocalDate.of(1990, 1, 1));
+
+    approve(person).name("john").byFile();
+    // end::approve_name[]
+  }
+
+  @Test
   void object_printer() {
     // tag::object_printer[]
     Person person = createPerson("John Doe", LocalDate.of(1990, 1, 1));
@@ -67,11 +76,11 @@ class BasicsDocTest {
   @Test
   void custom_printer() {
     // tag::custom_printer[]
-    Person person = createPerson("John Doe", LocalDate.of(1990, 1, 1));
+    Person jane = createPerson("Jane Doe", LocalDate.of(1990, 1, 1));
+    Person john = createPerson("John Doe", LocalDate.of(2012, 6, 2));
 
-    approve(person)
-        .printWith(new PersonYamlPrinter()) // <1>
-        .byFile();
+    approve(jane).name("jane").byFile();
+    approve(john).name("john").byFile();
     // end::custom_printer[]
   }
 

--- a/manual/src/test/kotlin/examples/kotlin/BasicsDocTest-approve_name-jane-approved.txt
+++ b/manual/src/test/kotlin/examples/kotlin/BasicsDocTest-approve_name-jane-approved.txt
@@ -1,0 +1,1 @@
+Person[name=Jane Doe, birthDate=1990-01-01]

--- a/manual/src/test/kotlin/examples/kotlin/BasicsDocTest-approve_name-john-approved.txt
+++ b/manual/src/test/kotlin/examples/kotlin/BasicsDocTest-approve_name-john-approved.txt
@@ -1,0 +1,1 @@
+Person[name=John Doe, birthDate=2012-06-02]

--- a/manual/src/test/kotlin/examples/kotlin/BasicsDocTest.kt
+++ b/manual/src/test/kotlin/examples/kotlin/BasicsDocTest.kt
@@ -40,6 +40,17 @@ class BasicsDocTest {
   }
 
   @Test
+  fun approve_name() {
+    // tag::approve_name[]
+    val jane = createPerson("Jane Doe", LocalDate.of(1990, 1, 1))
+    val john = createPerson("John Doe", LocalDate.of(2012, 6, 2))
+
+    approve(jane).name("jane").byFile()
+    approve(john).name("john").byFile()
+    // end::approve_name[]
+  }
+
+  @Test
   fun `object printer`() {
     // tag::object_printer[]
     val person = createPerson("John Doe", LocalDate.of(1990, 1, 1))

--- a/modules/core/src/main/java/org/approvej/ApprovalBuilder.java
+++ b/modules/core/src/main/java/org/approvej/ApprovalBuilder.java
@@ -60,11 +60,13 @@ import org.jspecify.annotations.Nullable;
 public class ApprovalBuilder<T> {
 
   private T receivedValue;
+  private String name = "";
   private final String filenameExtension;
   @Nullable private FileReviewer fileReviewer;
 
-  private ApprovalBuilder(T originalValue, String filenameExtension) {
+  private ApprovalBuilder(T originalValue, String name, String filenameExtension) {
     this.receivedValue = originalValue;
+    this.name = name;
     this.filenameExtension = filenameExtension;
     this.fileReviewer = configuration.defaultFileReviewer();
   }
@@ -77,7 +79,18 @@ public class ApprovalBuilder<T> {
    * @param <T> the type of the value to approve
    */
   public static <T> ApprovalBuilder<T> approve(T originalValue) {
-    return new ApprovalBuilder<>(originalValue, DEFAULT_FILENAME_EXTENSION);
+    return new ApprovalBuilder<>(originalValue, "", DEFAULT_FILENAME_EXTENSION);
+  }
+
+  /**
+   * Sets a name for the current approval. Generally this should
+   *
+   * @param name the name for the current approval
+   * @return this
+   */
+  public ApprovalBuilder<T> name(String name) {
+    this.name = name;
+    return this;
   }
 
   /**
@@ -88,7 +101,7 @@ public class ApprovalBuilder<T> {
    * @return a new {@link ApprovalBuilder} with the printed value
    */
   public ApprovalBuilder<String> printWith(Function<T, String> printer) {
-    return new ApprovalBuilder<>(printer.apply(receivedValue), DEFAULT_FILENAME_EXTENSION);
+    return new ApprovalBuilder<>(printer.apply(receivedValue), name, DEFAULT_FILENAME_EXTENSION);
   }
 
   /**
@@ -98,7 +111,7 @@ public class ApprovalBuilder<T> {
    * @return a new {@link ApprovalBuilder} with the printed value
    */
   public ApprovalBuilder<String> printWith(Printer<T> printer) {
-    return new ApprovalBuilder<>(printer.apply(receivedValue), printer.filenameExtension());
+    return new ApprovalBuilder<>(printer.apply(receivedValue), name, printer.filenameExtension());
   }
 
   /**
@@ -210,7 +223,7 @@ public class ApprovalBuilder<T> {
       // noinspection unchecked
       printWith((Printer<T>) configuration.defaultPrinter()).byFile(pathProviderBuilder);
     } else {
-      byFile(pathProviderBuilder.filenameExtension(filenameExtension));
+      byFile(pathProviderBuilder.filenameAffix(name).filenameExtension(filenameExtension));
     }
   }
 

--- a/modules/core/src/main/java/org/approvej/approve/StackTraceTestFinderUtil.java
+++ b/modules/core/src/main/java/org/approvej/approve/StackTraceTestFinderUtil.java
@@ -25,7 +25,8 @@ public class StackTraceTestFinderUtil {
    * @return the currently executing test {@link Method}
    */
   public static TestMethod currentTestMethod() {
-    return stream(Thread.currentThread().getStackTrace())
+    StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+    return stream(stackTrace)
         .map(
             element -> {
               try {

--- a/modules/core/src/main/java/org/approvej/scrub/Scrubbers.java
+++ b/modules/core/src/main/java/org/approvej/scrub/Scrubbers.java
@@ -185,6 +185,8 @@ public class Scrubbers {
    * {@code 2019-02-25T12:34:56.123456789}, {@code 2019-02-25T12:34:56+02:00}, or {@code
    * 2019-02-25T12:34:56.123456789+02:00[Europe/Berlin]}.
    *
+   * @param locale the {@link Locale} to localize the date/time pattern (influences names for zones
+   *     codes)
    * @return a {@link DateTimeScrubber} for ISO-8601 date/times
    * @see DateTimeFormatter#ISO_DATE_TIME
    */

--- a/modules/core/src/spock/groovy/org/approvej/approve/StackTraceTestFinderUtilSpockSpec.groovy
+++ b/modules/core/src/spock/groovy/org/approvej/approve/StackTraceTestFinderUtilSpockSpec.groovy
@@ -8,9 +8,9 @@ import static java.nio.file.Files.copy
 import static java.nio.file.Files.createDirectories
 import static java.nio.file.Files.delete
 
-class StackTraceTestFinderUtilSpec extends Specification {
+class StackTraceTestFinderUtilSpockSpec extends Specification {
 
-  private final Path thisTestSourcePath = Path.of("src/spock/groovy/org/approvej/approve/StackTraceTestFinderUtilSpec.groovy")
+  private final Path thisTestSourcePath = Path.of("src/spock/groovy/org/approvej/approve/StackTraceTestFinderUtilSpockSpec.groovy")
   private final List<Path> wrongTestSourcePathsToCleanup = []
 
   def 'currentTestMethod'() {
@@ -20,7 +20,7 @@ class StackTraceTestFinderUtilSpec extends Specification {
     then:
     verifyAll(currentTestMethod) {
       method()
-      testClass() == StackTraceTestFinderUtilSpec
+      testClass() == StackTraceTestFinderUtilSpockSpec
       testCaseName() == 'currentTestMethod'
     }
   }

--- a/modules/core/src/test/java/org/approvej/approve/NextToTestPathProviderTest.java
+++ b/modules/core/src/test/java/org/approvej/approve/NextToTestPathProviderTest.java
@@ -77,4 +77,30 @@ class NextToTestPathProviderTest {
                 .toAbsolutePath()
                 .normalize());
   }
+
+  @Test
+  void paths_filenameAffix() {
+    PathProvider pathProvider =
+        nextToTest().filenameAffix("additional info").filenameExtension("txt");
+    assertThat(pathProvider.approvedPath())
+        .isEqualTo(
+            Path.of(
+                    "./src/test/java/org/approvej/approve/"
+                        + "NextToTestPathProviderTest"
+                        + "-paths_filenameAffix"
+                        + "-additional info"
+                        + "-approved.txt")
+                .toAbsolutePath()
+                .normalize());
+    assertThat(pathProvider.receivedPath())
+        .isEqualTo(
+            Path.of(
+                    "./src/test/java/org/approvej/approve/"
+                        + "NextToTestPathProviderTest"
+                        + "-paths_filenameAffix"
+                        + "-additional info"
+                        + "-received.txt")
+                .toAbsolutePath()
+                .normalize());
+  }
 }

--- a/modules/core/src/test/java/org/approvej/approve/StackTraceTestFinderUtilTest.java
+++ b/modules/core/src/test/java/org/approvej/approve/StackTraceTestFinderUtilTest.java
@@ -12,6 +12,8 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class StackTraceTestFinderUtilTest {
 
@@ -29,6 +31,18 @@ class StackTraceTestFinderUtilTest {
   @Test
   void currentTestMethod() throws NoSuchMethodException {
     Method thisMethod = getClass().getDeclaredMethod("currentTestMethod");
+
+    TestMethod currentTestMethod = StackTraceTestFinderUtil.currentTestMethod();
+
+    assertThat(currentTestMethod.method()).isEqualTo(thisMethod);
+    assertThat(currentTestMethod.testClass()).isEqualTo(thisMethod.getDeclaringClass());
+    assertThat(currentTestMethod.testCaseName()).isEqualTo(thisMethod.getName());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"a", "b", "c"})
+  void currentTestMethod_parameterized_test() throws NoSuchMethodException {
+    Method thisMethod = getClass().getDeclaredMethod("currentTestMethod_parameterized_test");
 
     TestMethod currentTestMethod = StackTraceTestFinderUtil.currentTestMethod();
 

--- a/modules/core/src/testng/java/org/approvej/approve/StackTraceTestFinderUtilTestNgTest.java
+++ b/modules/core/src/testng/java/org/approvej/approve/StackTraceTestFinderUtilTestNgTest.java
@@ -13,10 +13,10 @@ import java.util.List;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.Test;
 
-public class StackTraceTestFinderUtilTest {
+public class StackTraceTestFinderUtilTestNgTest {
 
   private final Path thisTestSourcePath =
-      Path.of("src/testng/java/org/approvej/approve/StackTraceTestFinderUtilTest.java");
+      Path.of("src/testng/java/org/approvej/approve/StackTraceTestFinderUtilTestNgTest.java");
   private final List<Path> wrongTestSourcePathsToCleanup = new ArrayList<>();
 
   @AfterTest


### PR DESCRIPTION
The new name method in the ApprovalBuilder allows to set a custom name
for an approval.
This is necessary especially if there are multiple approvals in one test
 case as the determined filenames will be the same for all approvals in
 the same test case.
