### PR TITLE
Make Jackson a provided dependency

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "allow": [
+      "WebSearch",
+      "WebFetch(domain:blog.gradle.org)",
+      "Bash(ls:*)",
+      "WebFetch(domain:docs.gradle.org)",
+      "WebFetch(domain:github.com)",
+      "Bash(./gradlew :spotlessApply:*)",
+      "Bash(./gradlew build:*)",
+      "Bash(./gradlew:*)"
+    ]
+  }
+}

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -11,5 +11,9 @@ dependencies {
       .filter { it != project && it.name != "manual" && it.subprojects.isEmpty() }
       .sortedBy { it.name }
       .forEach { api(it) }
+
+    api(libs.jackson.databind)
+    api(libs.jackson.jsr310)
+    api(libs.jackson.dataformat.yaml)
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 awaitility = { module = "org.awaitility:awaitility", version = "4.3.0" }
 groovy = { module = "org.apache.groovy:groovy" , version = "5.0.4" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
-jackson-datafromat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
+jackson-dataformat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
 jackson-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
 jspecify = { module = "org.jspecify:jspecify", version = "1.0.0" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }

--- a/manual/build.gradle.kts
+++ b/manual/build.gradle.kts
@@ -26,6 +26,10 @@ testing {
           implementation(project(":modules:json-jackson"))
           implementation(project(":modules:yaml-jackson"))
 
+          implementation(libs.jackson.databind)
+          implementation(libs.jackson.dataformat.yaml)
+          implementation(libs.jackson.jsr310)
+
           implementation(platform(libs.junit.bom))
           implementation(libs.junit.jupiter.api)
           implementation(libs.junit.jupiter.params)

--- a/manual/src/docs/asciidoc/chapters/07-json-jackson.adoc
+++ b/manual/src/docs/asciidoc/chapters/07-json-jackson.adoc
@@ -3,16 +3,21 @@
 The `json-jackson` module provides several JSON-related features implemented with https://github.com/FasterXML/jackson[Jackson].
 
 To use it, you need to add it as a dependency to your project.
+Since Jackson is a provided dependency, you also need to add Jackson explicitly.
 
 .Gradle
 [source,groovy,subs=attributes+,role="primary"]
 ----
 implementation 'org.approvej:json-jackson:{revnumber}'
+implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.0'
+implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.0'
 ----
 .Gradle.kts
 [source,kotlin,subs=attributes+,role="secondary"]
 ----
 implementation("org.approvej:json-jackson:{revnumber}")
+implementation("com.fasterxml.jackson.core:jackson-databind:2.18.0")
+implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.0")
 ----
 .Maven
 [source,xml,subs=attributes+,role="secondary"]
@@ -25,10 +30,22 @@ implementation("org.approvej:json-jackson:{revnumber}")
       <artifactId>json-jackson</artifactId>
       <version>{revnumber}</version>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.18.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>2.18.0</version>
+    </dependency>
   </dependencies>
   <!-- … -->
 </project>
 ----
+
+TIP: If you use the ApproveJ BOM, you can omit the Jackson version numbers as the BOM provides recommended versions.
 
 
 == Scrub JSON

--- a/modules/json-jackson/build.gradle.kts
+++ b/modules/json-jackson/build.gradle.kts
@@ -18,8 +18,9 @@ repositories { mavenCentral() }
 dependencies {
   api(project(":modules:core"))
   api(libs.jspecify)
-  api(libs.jackson.databind)
-  api(libs.jackson.jsr310)
+
+  compileOnly(libs.jackson.databind)
+  compileOnly(libs.jackson.jsr310)
 }
 
 testing {
@@ -28,7 +29,9 @@ testing {
       getting(JvmTestSuite::class) {
         useJUnitJupiter()
         dependencies {
+          implementation(libs.jackson.databind)
           implementation(libs.jackson.jsr310)
+
           implementation(platform(libs.junit.bom))
           implementation(libs.junit.jupiter.api)
           implementation(libs.junit.jupiter.params)

--- a/modules/json-jackson/src/main/java/org/approvej/json/jackson/JsonPrintFormat.java
+++ b/modules/json-jackson/src/main/java/org/approvej/json/jackson/JsonPrintFormat.java
@@ -23,6 +23,16 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public final class JsonPrintFormat<T> implements PrintFormat<T>, PrintFormatProvider<T> {
 
+  static {
+    try {
+      Class.forName("com.fasterxml.jackson.databind.ObjectMapper");
+    } catch (ClassNotFoundException e) {
+      throw new IllegalStateException(
+          "Jackson is required but not found on classpath. "
+              + "Add com.fasterxml.jackson.core:jackson-databind to your dependencies.");
+    }
+  }
+
   private static final ObjectMapper DEFAULT_JSON_MAPPER =
       JsonMapper.builder().addModule(new JavaTimeModule()).build();
 

--- a/modules/yaml-jackson/build.gradle.kts
+++ b/modules/yaml-jackson/build.gradle.kts
@@ -18,9 +18,10 @@ repositories { mavenCentral() }
 dependencies {
   api(project(":modules:core"))
   api(libs.jspecify)
-  api(libs.jackson.databind)
-  api(libs.jackson.datafromat.yaml)
-  api(libs.jackson.jsr310)
+
+  compileOnly(libs.jackson.databind)
+  compileOnly(libs.jackson.dataformat.yaml)
+  compileOnly(libs.jackson.jsr310)
 }
 
 testing {
@@ -29,6 +30,10 @@ testing {
       getting(JvmTestSuite::class) {
         useJUnitJupiter()
         dependencies {
+          implementation(libs.jackson.databind)
+          implementation(libs.jackson.dataformat.yaml)
+          implementation(libs.jackson.jsr310)
+
           implementation(platform(libs.junit.bom))
           implementation(libs.junit.jupiter.api)
           implementation(libs.junit.jupiter.params)

--- a/modules/yaml-jackson/src/main/java/org/approvej/yaml/jackson/YamlPrintFormat.java
+++ b/modules/yaml-jackson/src/main/java/org/approvej/yaml/jackson/YamlPrintFormat.java
@@ -24,6 +24,16 @@ import org.jspecify.annotations.NullMarked;
 public record YamlPrintFormat<T>(ObjectWriter objectWriter)
     implements PrintFormat<T>, PrintFormatProvider<T> {
 
+  static {
+    try {
+      Class.forName("com.fasterxml.jackson.dataformat.yaml.YAMLMapper");
+    } catch (ClassNotFoundException e) {
+      throw new IllegalStateException(
+          "Jackson YAML is required but not found on classpath. Add"
+              + " com.fasterxml.jackson.dataformat:jackson-dataformat-yaml to your dependencies.");
+    }
+  }
+
   private static final YAMLMapper DEFAULT_YAML_MAPPER =
       YAMLMapper.builder().addModule(new JavaTimeModule()).build();
 


### PR DESCRIPTION
Jackson is now a compileOnly dependency in json-jackson and yaml-jackson
modules. Users must explicitly add Jackson to their projects. The BOM
provides recommended version constraints. Static initializers in
JsonPrintFormat and YamlPrintFormat check for Jackson availability and
provide helpful error messages if missing.
