### PR TITLE
Separate IntelliJ plugin versioning and release

### DIFF
--- a/.github/workflows/publish-intellij-plugin.yml
+++ b/.github/workflows/publish-intellij-plugin.yml
@@ -1,0 +1,31 @@
+name: Publish IntelliJ Plugin
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Plugin version to publish (e.g. 1.4.3)'
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: temurin
+
+      - uses: gradle/actions/setup-gradle@cd4b95f1dffd155d6d8f6b8c195a3ff2f9f77a5d
+
+      - run: ./gradlew :plugins:approvej-intellij-plugin:publishPlugin -Pversion=${{ github.event.inputs.version }}
+        env:
+          INTELLIJ_MARKETPLACE_TOKEN: ${{ secrets.INTELLIJ_MARKETPLACE_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,9 +44,6 @@ jobs:
         env:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
-      - run: ./gradlew :plugins:approvej-intellij-plugin:publishPlugin -Pversion=${{ github.event.inputs.version }}
-        env:
-          INTELLIJ_MARKETPLACE_TOKEN: ${{ secrets.INTELLIJ_MARKETPLACE_TOKEN }}
       - name: Extract release notes for version
         run: awk '/^## v${{ github.event.inputs.version }}$/{found=1; next} /^## v/{if(found) exit} found' CHANGELOG.md > RELEASE_NOTES.md
       - run: ./gradlew jreleaserFullRelease -Pversion=${{ github.event.inputs.version }} --git-root-search --stacktrace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,43 +3,6 @@
 
 ## Unreleased
 
-### approvej-intellij-plugin
-
-* ✨ **Rename refactoring support for approved files**
-  When renaming a test class or method via IntelliJ's refactoring (Shift+F6),
-  approved and received files are now automatically renamed along with it.
-  Supports both Java and Kotlin, next-to-test and subdirectory naming patterns,
-  affixed files, and keeps the inventory in sync.
-
-
-## v1.4.2
-
-### approvej-intellij-plugin
-
-* ✨ **Plugin recommendations via dependency support**
-  IntelliJ now suggests the ApproveJ plugin when a project uses any ApproveJ dependency.
-
-* 🎨 **Custom gutter icons**
-  Gutter markers use dedicated ApproveJ icons: green for approved, orange when a received file exists.
-
-* 📝 **Improved Marketplace listing**
-  Richer plugin description with feature list and automated change notes from the changelog.
-
-**Full Changelog**: https://github.com/mkutz/ApproveJ/compare/v1.4.1...v1.4.2
-
-
-## v1.4.1
-
-### approvej-intellij-plugin
-
-* 🐞 **Fix navigation in multi-module Gradle projects**
-  The IntelliJ plugin only looked for a single inventory file at the project root.
-  In multi-module projects each module writes its own `.approvej/inventory.properties`,
-  so navigation features (gutter icons, editor banners) found nothing.
-  The plugin now discovers and merges all inventory files across modules.
-
-**Full Changelog**: https://github.com/mkutz/ApproveJ/compare/v1.4...v1.4.1
-
 
 ## v1.4
 
@@ -50,30 +13,6 @@
   Annotate your test class with `@ApprovalTest` to enable a JUnit `AfterEachCallback` that fails
   the test when a dangling approval is found. A shutdown hook provides a fallback warning when
   the extension is not active.
-
-
-### 🆕 approvej-intellij-plugin
-
-A new IntelliJ IDEA plugin reduces friction when working with `.received` files directly in your IDE:
-
-* 👀 **Diff viewer**
-  Open a side-by-side diff between the received and approved file from the editor notification
-  banner or via context menu actions in the Project View and Editor.
-
-* ✅ **One-click approve**
-  Approve a received file with a single click — copies received to approved and deletes the
-  received file. The action is undoable via IntelliJ's undo mechanism.
-
-* 🧭 **Bidirectional navigation**
-  Gutter icons on `approve()…byFile()` chains navigate to the approved file.
-  When a received file exists, a popup offers to compare or navigate to either file.
-  Editor banners on approved and received files link back to the test method via inventory lookup.
-
-* 🔍 **Dangling approval inspection**
-  A UAST-based code inspection highlights `approve()` calls not concluded with a terminal method
-  and offers quick fixes to append `.byFile()` or `.byValue("")`.
-
-See [manual](https://approvej.org/#intellij_plugin)
 
 
 ### manual

--- a/plugins/approvej-intellij-plugin/CHANGELOG.md
+++ b/plugins/approvej-intellij-plugin/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+
+## Unreleased
+
+* ✨ **Rename refactoring support for approved files**
+  When renaming a test class or method via IntelliJ's refactoring (Shift+F6),
+  approved and received files are now automatically renamed along with it.
+  Supports both Java and Kotlin, next-to-test and subdirectory naming patterns,
+  affixed files, and keeps the inventory in sync.
+
+* 🐞 **Fix gutter icon filtering for nextToTest naming pattern**
+  Gutter icons now correctly match approved files using the default `nextToTest`
+  naming pattern where filenames include the class name prefix.
+
+
+## v1.4.2
+
+* ✨ **Plugin recommendations via dependency support**
+  IntelliJ now suggests the ApproveJ plugin when a project uses any ApproveJ dependency.
+
+* 🎨 **Custom gutter icons**
+  Gutter markers use dedicated ApproveJ icons: green for approved, orange when a received file exists.
+
+* 📝 **Improved Marketplace listing**
+  Richer plugin description with feature list and automated change notes from the changelog.
+
+
+## v1.4.1
+
+* 🐞 **Fix navigation in multi-module Gradle projects**
+  The IntelliJ plugin only looked for a single inventory file at the project root.
+  In multi-module projects each module writes its own `.approvej/inventory.properties`,
+  so navigation features (gutter icons, editor banners) found nothing.
+  The plugin now discovers and merges all inventory files across modules.
+
+
+## v1.4
+
+A new IntelliJ IDEA plugin reduces friction when working with `.received` files directly in your IDE:
+
+* 👀 **Diff viewer**
+  Open a side-by-side diff between the received and approved file from the editor notification
+  banner or via context menu actions in the Project View and Editor.
+
+* ✅ **One-click approve**
+  Approve a received file with a single click — copies received to approved and deletes the
+  received file. The action is undoable via IntelliJ's undo mechanism.
+
+* 🧭 **Bidirectional navigation**
+  Gutter icons on `approve()…byFile()` chains navigate to the approved file.
+  When a received file exists, a popup offers to compare or navigate to either file.
+  Editor banners on approved and received files link back to the test method via inventory lookup.
+
+* 🔍 **Dangling approval inspection**
+  A UAST-based code inspection highlights `approve()` calls not concluded with a terminal method
+  and offers quick fixes to append `.byFile()` or `.byValue("")`.
+
+See [manual](https://approvej.org/#intellij_plugin)

--- a/plugins/approvej-intellij-plugin/build.gradle.kts
+++ b/plugins/approvej-intellij-plugin/build.gradle.kts
@@ -50,7 +50,7 @@ intellijPlatform {
 }
 
 fun extractChangeNotes(version: String): String {
-  val changelog = rootProject.file("CHANGELOG.md")
+  val changelog = project.file("CHANGELOG.md")
   if (!changelog.exists()) return ""
   val lines = changelog.readLines()
   val versionStart = lines.indexOfFirst { it.trimEnd() == "## v$version" }
@@ -60,20 +60,7 @@ fun extractChangeNotes(version: String): String {
       .drop(versionStart + 1)
       .indexOfFirst { it.startsWith("## v") }
       .let { if (it == -1) lines.size else it + versionStart + 1 }
-  val versionLines = lines.subList(versionStart + 1, versionEnd)
-  val pluginStart =
-    versionLines.indexOfFirst { it.trimEnd().matches(Regex("###.*approvej-intellij-plugin")) }
-  if (pluginStart == -1) return ""
-  val pluginEnd =
-    versionLines
-      .drop(pluginStart + 1)
-      .indexOfFirst { it.startsWith("### ") }
-      .let { if (it == -1) versionLines.size else it + pluginStart + 1 }
-  return versionLines
-    .subList(pluginStart + 1, pluginEnd)
-    .filter { !it.startsWith("**Full Changelog**") }
-    .joinToString("\n")
-    .trim()
+  return lines.subList(versionStart + 1, versionEnd).joinToString("\n").trim()
 }
 
 /* Use JUnit 5.11 for IntelliJ platform tests to avoid version conflicts with IntelliJ's test

--- a/plugins/approvej-intellij-plugin/gradle.properties
+++ b/plugins/approvej-intellij-plugin/gradle.properties
@@ -1,0 +1,1 @@
+version=1.4.3-SNAPSHOT


### PR DESCRIPTION
## Summary

- Give the IntelliJ plugin its own `gradle.properties` version and `CHANGELOG.md`
- Add a dedicated `publish-intellij-plugin.yml` workflow
- Remove the IntelliJ plugin publish step from the main `publish.yml`
- Migrate all IntelliJ plugin changelog entries from root to plugin-local changelog
- Simplify `extractChangeNotes` since it no longer needs to find a subsection

The plugin keeps the same `major.minor` as core to signal compatibility, with an independent patch counter (e.g. core `1.4.2`, plugin `1.4.3`).

Closes #232

## Test plan

- [x] `./gradlew :plugins:approvej-intellij-plugin:test` passes
- [x] Plugin version resolves to `1.4.3-SNAPSHOT` from its own `gradle.properties`
- [x] Root project and core module still use root `SNAPSHOT` version
- [ ] Verify CI build passes