### PR TITLE
Normalize inventory paths to forward slashes

### DIFF
--- a/modules/core/src/main/java/org/approvej/approve/ApprovedFileInventory.java
+++ b/modules/core/src/main/java/org/approvej/approve/ApprovedFileInventory.java
@@ -182,7 +182,8 @@ public class ApprovedFileInventory {
                     entry ->
                         "%s = %s"
                             .formatted(
-                                escapeKey(entry.relativePath().toString()), entry.testReference()))
+                                escapeKey(entry.relativePath().toString().replace('\\', '/')),
+                                entry.testReference()))
                 .collect(joining("\n", HEADER + "\n", "\n"));
         Files.writeString(inventoryPath, content);
       }

--- a/modules/core/src/test/java/org/approvej/approve/ApprovedFileInventoryTest.java
+++ b/modules/core/src/test/java/org/approvej/approve/ApprovedFileInventoryTest.java
@@ -1,5 +1,6 @@
 package org.approvej.approve;
 
+import static java.nio.file.Files.readString;
 import static java.nio.file.Files.writeString;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -225,6 +226,22 @@ class ApprovedFileInventoryTest {
     assertThat(nestedPath).exists();
     var loaded = ApprovedFileInventory.loadInventory(nestedPath);
     assertThat(loaded.entries()).hasSize(1);
+  }
+
+  @Test
+  void saveInventory_uses_forward_slashes() throws IOException {
+    var inventory =
+        new ApprovedFileInventory(
+            List.of(
+                new InventoryEntry(
+                    Path.of("src\\test\\MyTest-myTest-approved.txt"), "com.example.MyTest#myTest")),
+            inventoryPath());
+
+    inventory.saveInventory();
+
+    var content = readString(inventoryPath());
+    assertThat(content).contains("src/test/MyTest-myTest-approved.txt");
+    assertThat(content).doesNotContain("\\");
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Normalizes backslashes to forward slashes when writing paths to the inventory properties file
- Adds a test that reproduces the bug on any OS by constructing a path with backslashes

`Path.toString()` uses `\` on Windows, making the inventory file contain OS-specific separators. Since the inventory is checked into version control, this causes cross-platform inconsistencies. Forward slashes work in `Path.of()` on all platforms, so only the write side needs the fix.

Closes #239