### PR TITLE
Capture ISO instants without fractions of a second

### DIFF
--- a/modules/core/src/main/java/org/approvej/scrub/Scrubbers.java
+++ b/modules/core/src/main/java/org/approvej/scrub/Scrubbers.java
@@ -253,13 +253,13 @@ public class Scrubbers {
 
   /**
    * Creates a {@link DateTimeScrubber} for ISO-8601 instants, like {@code
-   * 2019-02-25T12:34:56.123456789+02:00}, or {@code 2019-02-25T12:34:56.123456789Z}.
+   * 2019-02-25T12:34:56.123456789Z}, or {@code 2019-02-25T12:34:56Z}.
    *
    * @return a {@link DateTimeScrubber} for ISO-8601 instants
    * @see DateTimeFormatter#ISO_INSTANT
    */
   public static DateTimeScrubber isoInstants() {
-    return dateTimeFormat("uuuu-MM-dd'T'HH:mm:ss.SX").replacement(numbered("isoInstant"));
+    return dateTimeFormat("uuuu-MM-dd'T'HH:mm:ss[.S]X").replacement(numbered("isoInstant"));
   }
 
   /**

--- a/modules/core/src/test/java/org/approvej/scrub/DateTimeScrubberTest.java
+++ b/modules/core/src/test/java/org/approvej/scrub/DateTimeScrubberTest.java
@@ -10,6 +10,7 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -243,6 +244,18 @@ class DateTimeScrubberTest {
                 .apply(
                     "isoInstant: %s"
                         .formatted(DateTimeFormatter.ISO_INSTANT.format(ZonedDateTime.now()))))
+        .isEqualTo("isoInstant: [isoInstant 1]");
+  }
+
+  @Test
+  void isoInstantsNoFractions() {
+    assertThat(
+            Scrubbers.isoInstants()
+                .apply(
+                    "isoInstant: %s"
+                        .formatted(
+                            DateTimeFormatter.ISO_INSTANT.format(
+                                ZonedDateTime.now().truncatedTo(ChronoUnit.SECONDS)))))
         .isEqualTo("isoInstant: [isoInstant 1]");
   }
 


### PR DESCRIPTION
Make fractions of a second in Scrubbers.isoInstants() optional so that instants are also captured without them.