### PR TITLE
Suppress built-in diff tools for ApproveJ image diffs

### DIFF
--- a/plugins/approvej-intellij-plugin/src/main/kotlin/org/approvej/intellij/ImageDiffTool.kt
+++ b/plugins/approvej-intellij-plugin/src/main/kotlin/org/approvej/intellij/ImageDiffTool.kt
@@ -23,7 +23,7 @@ import javax.swing.SwingConstants
 private val IMAGE_EXTENSIONS = setOf("png", "jpg", "jpeg", "gif", "bmp", "webp")
 private const val IMAGE_COLUMNS = 3
 
-private fun isImageFile(filename: String): Boolean {
+internal fun isImageFile(filename: String): Boolean {
   val extension = filename.substringAfterLast('.', "").lowercase()
   return extension in IMAGE_EXTENSIONS
 }

--- a/plugins/approvej-intellij-plugin/src/test/kotlin/org/approvej/intellij/ImageDiffToolTest.kt
+++ b/plugins/approvej-intellij-plugin/src/test/kotlin/org/approvej/intellij/ImageDiffToolTest.kt
@@ -1,0 +1,41 @@
+package org.approvej.intellij
+
+import com.intellij.diff.tools.binary.BinaryDiffTool
+import com.intellij.diff.tools.simple.SimpleDiffTool
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ImageDiffToolTest {
+
+  private val tool = ImageDiffTool()
+
+  @Test
+  fun name() {
+    assertThat(tool.name).isEqualTo("ApproveJ Image Diff")
+  }
+
+  @Test
+  fun suppressedTools() {
+    assertThat(tool.suppressedTools)
+      .containsExactly(SimpleDiffTool::class.java, BinaryDiffTool::class.java)
+  }
+
+  @Test
+  fun isImageFile() {
+    assertThat(isImageFile("photo.png")).isTrue()
+    assertThat(isImageFile("photo.PNG")).isTrue()
+    assertThat(isImageFile("photo.jpg")).isTrue()
+    assertThat(isImageFile("photo.jpeg")).isTrue()
+    assertThat(isImageFile("photo.gif")).isTrue()
+    assertThat(isImageFile("photo.bmp")).isTrue()
+    assertThat(isImageFile("photo.webp")).isTrue()
+  }
+
+  @Test
+  fun isImageFile_non_image() {
+    assertThat(isImageFile("document.txt")).isFalse()
+    assertThat(isImageFile("code.java")).isFalse()
+    assertThat(isImageFile("data.json")).isFalse()
+    assertThat(isImageFile("noextension")).isFalse()
+  }
+}


### PR DESCRIPTION
## Summary

- `ImageDiffTool` now implements `SuppressiveDiffTool` to suppress `SimpleDiffTool` and `BinaryDiffTool` when showing ApproveJ image diffs
- Without this, IntelliJ's built-in tools appeared first in the tool order and the three-panel image diff viewer was never selected
- Also addresses IDE inspection warnings: uses `JBScrollPane`, removes companion object function, extracts constant

Fixes #272

## Test plan

- [x] Manual verification: gutter icon on image approval now opens the three-panel image diff
- [x] `./gradlew :plugins:approvej-intellij-plugin:check` passes