### PR TITLE
Add approvej.properties support to IntelliJ plugin

### DIFF
--- a/plugins/approvej-intellij-plugin/build.gradle.kts
+++ b/plugins/approvej-intellij-plugin/build.gradle.kts
@@ -45,6 +45,8 @@ intellijPlatform {
             to the test method.</li>
         <li><b>Dangling approval inspection</b> — highlights <code>approve()</code> calls missing a
             terminal method and offers quick fixes.</li>
+        <li><b>Properties file support</b> — autocompletion, unknown key warnings, and deprecation
+            hints for <code>approvej.properties</code> files.</li>
       </ul>
 
       <p>See the <a href="https://approvej.org/#intellij_plugin">documentation</a> for details.</p>
@@ -79,6 +81,7 @@ dependencies {
   intellijPlatform {
     intellijIdeaCommunity(libs.versions.intellij.ide)
     bundledPlugin("com.intellij.java")
+    bundledPlugin("com.intellij.properties")
     testFramework(TestFrameworkType.Platform)
     testFramework(TestFrameworkType.Plugin.Java)
   }

--- a/plugins/approvej-intellij-plugin/src/main/kotlin/org/approvej/intellij/ApproveJImplicitPropertyUsageProvider.kt
+++ b/plugins/approvej-intellij-plugin/src/main/kotlin/org/approvej/intellij/ApproveJImplicitPropertyUsageProvider.kt
@@ -1,0 +1,14 @@
+package org.approvej.intellij
+
+import com.intellij.lang.properties.codeInspection.unused.ImplicitPropertyUsageProvider
+import com.intellij.lang.properties.psi.Property
+
+/**
+ * Marks all properties in `approvej.properties` files as implicitly used so the built-in "Unused
+ * property" inspection does not flag them.
+ */
+class ApproveJImplicitPropertyUsageProvider : ImplicitPropertyUsageProvider {
+
+  override fun isUsed(property: Property): Boolean =
+    property.containingFile?.name == ApproveJProperties.FILE_NAME
+}

--- a/plugins/approvej-intellij-plugin/src/main/kotlin/org/approvej/intellij/ApproveJProperties.kt
+++ b/plugins/approvej-intellij-plugin/src/main/kotlin/org/approvej/intellij/ApproveJProperties.kt
@@ -1,0 +1,35 @@
+package org.approvej.intellij
+
+internal object ApproveJProperties {
+
+  const val FILE_NAME = "approvej.properties"
+
+  data class PropertyDef(
+    val key: String,
+    val knownValues: List<String>? = null,
+    val deprecated: Boolean = false,
+    val deprecationMessage: String? = null,
+  )
+
+  val ALL: List<PropertyDef> =
+    listOf(
+      PropertyDef(
+        "defaultPrintFormat",
+        listOf("singleLineString", "multiLineString", "json", "yaml"),
+      ),
+      PropertyDef("defaultFileReviewer", listOf("none", "automatic", "script", "ai")),
+      PropertyDef("reviewerScript"),
+      PropertyDef("reviewerAiCommand"),
+      PropertyDef("inventoryEnabled", listOf("true", "false")),
+      PropertyDef("defaultInlineValueReviewer", listOf("none", "automatic", "script", "ai")),
+      PropertyDef(
+        key = "defaultFileReviewerScript",
+        deprecated = true,
+        deprecationMessage =
+          "'defaultFileReviewerScript' is deprecated." +
+            " Use 'defaultFileReviewer = script' and 'reviewerScript = ...' instead.",
+      ),
+    )
+
+  val BY_KEY: Map<String, PropertyDef> = ALL.associateBy { it.key }
+}

--- a/plugins/approvej-intellij-plugin/src/main/kotlin/org/approvej/intellij/ApproveJPropertiesCompletionContributor.kt
+++ b/plugins/approvej-intellij-plugin/src/main/kotlin/org/approvej/intellij/ApproveJPropertiesCompletionContributor.kt
@@ -1,0 +1,60 @@
+package org.approvej.intellij
+
+import com.intellij.codeInsight.completion.CompletionContributor
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.lang.properties.psi.Property
+
+/**
+ * Provides autocompletion for property keys and values in `approvej.properties` files.
+ *
+ * In key position, all known property keys are offered. Deprecated keys are shown with
+ * strikethrough. In value position, known values for the property key are offered.
+ */
+class ApproveJPropertiesCompletionContributor : CompletionContributor() {
+
+  override fun fillCompletionVariants(
+    parameters: CompletionParameters,
+    result: CompletionResultSet,
+  ) {
+    val file = parameters.originalFile
+    if (file.name != ApproveJProperties.FILE_NAME) return
+
+    val position = parameters.position
+    val property = position.parent as? Property
+
+    if (property == null) {
+      addKeyCompletions(result)
+      return
+    }
+
+    if (isValuePosition(parameters, property)) {
+      addValueCompletions(property, result)
+    } else {
+      addKeyCompletions(result)
+    }
+  }
+
+  private fun isValuePosition(parameters: CompletionParameters, property: Property): Boolean {
+    val keyElement = property.firstChild ?: return false
+    return parameters.offset > keyElement.textRange.endOffset
+  }
+
+  private fun addKeyCompletions(result: CompletionResultSet) {
+    for (definition in ApproveJProperties.ALL) {
+      val element =
+        LookupElementBuilder.create(definition.key).withStrikeoutness(definition.deprecated)
+      result.addElement(element)
+    }
+  }
+
+  private fun addValueCompletions(property: Property, result: CompletionResultSet) {
+    val key = property.key ?: return
+    val definition = ApproveJProperties.BY_KEY[key] ?: return
+    val knownValues = definition.knownValues ?: return
+    for (value in knownValues) {
+      result.addElement(LookupElementBuilder.create(value))
+    }
+  }
+}

--- a/plugins/approvej-intellij-plugin/src/main/kotlin/org/approvej/intellij/ApproveJPropertiesInspection.kt
+++ b/plugins/approvej-intellij-plugin/src/main/kotlin/org/approvej/intellij/ApproveJPropertiesInspection.kt
@@ -1,0 +1,59 @@
+package org.approvej.intellij
+
+import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.lang.properties.psi.PropertiesFile
+import com.intellij.lang.properties.psi.Property
+import com.intellij.psi.PsiFile
+
+/**
+ * Inspection that warns about unknown or deprecated property keys in `approvej.properties` files.
+ *
+ * Unknown keys are highlighted as warnings; deprecated keys are rendered with strikethrough.
+ */
+class ApproveJPropertiesInspection : LocalInspectionTool() {
+
+  override fun checkFile(
+    file: PsiFile,
+    manager: InspectionManager,
+    isOnTheFly: Boolean,
+  ): Array<ProblemDescriptor>? {
+    if (file.name != ApproveJProperties.FILE_NAME) return null
+    val propertiesFile = file as? PropertiesFile ?: return null
+
+    val problems = mutableListOf<ProblemDescriptor>()
+    for (property in propertiesFile.properties) {
+      val key = property.key ?: continue
+      val keyElement = (property as? Property)?.firstChild ?: continue
+      val definition = ApproveJProperties.BY_KEY[key]
+
+      if (definition == null) {
+        problems +=
+          manager.createProblemDescriptor(
+            keyElement,
+            "Unknown ApproveJ property key '$key'",
+            isOnTheFly,
+            emptyArray(),
+            ProblemHighlightType.WARNING,
+          )
+      } else if (definition.deprecated) {
+        problems +=
+          manager.createProblemDescriptor(
+            keyElement,
+            definition.deprecationMessage ?: "Deprecated property key '$key'",
+            isOnTheFly,
+            emptyArray(),
+            ProblemHighlightType.LIKE_DEPRECATED,
+          )
+      }
+    }
+    return problems.toTypedArray().ifEmpty { null }
+  }
+
+  override fun getStaticDescription(): String =
+    "Reports unknown or deprecated property keys in <code>approvej.properties</code> files." +
+      " Unknown keys may indicate typos. Deprecated keys should be replaced with their" +
+      " modern equivalents."
+}

--- a/plugins/approvej-intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugins/approvej-intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -6,12 +6,14 @@
   <description><![CDATA[
     Approval testing support for ApproveJ.
     Provides diff viewing, one-click approval, bidirectional navigation between
-    test code and approved files, dangling approval detection, and duplicate
-    unnamed approval detection.
+    test code and approved files, dangling approval detection, duplicate
+    unnamed approval detection, and approvej.properties editing support
+    with autocompletion and validation.
   ]]></description>
 
   <depends>com.intellij.modules.platform</depends>
   <depends>com.intellij.modules.java</depends>
+  <depends>com.intellij.properties</depends>
 
   <extensions defaultExtensionNs="com.intellij">
     <dependencySupport kind="java" coordinate="org.approvej:core" displayName="ApproveJ"/>
@@ -52,6 +54,19 @@
         implementation="org.approvej.intellij.ApproveJRenamePsiElementProcessor"/>
     <refactoring.elementListenerProvider
         implementation="org.approvej.intellij.ApproveJRefactoringListenerProvider"/>
+    <localInspection
+        language="Properties"
+        groupName="ApproveJ"
+        shortName="ApproveJUnknownProperty"
+        displayName="Unknown or deprecated ApproveJ property key"
+        enabledByDefault="true"
+        level="WARNING"
+        implementationClass="org.approvej.intellij.ApproveJPropertiesInspection"/>
+    <completion.contributor
+        language="Properties"
+        implementationClass="org.approvej.intellij.ApproveJPropertiesCompletionContributor"/>
+    <properties.implicitPropertyUsageProvider
+        implementation="org.approvej.intellij.ApproveJImplicitPropertyUsageProvider"/>
   </extensions>
 
   <actions>

--- a/plugins/approvej-intellij-plugin/src/test/kotlin/org/approvej/intellij/ApproveJPropertiesCompletionTest.kt
+++ b/plugins/approvej-intellij-plugin/src/test/kotlin/org/approvej/intellij/ApproveJPropertiesCompletionTest.kt
@@ -1,0 +1,66 @@
+package org.approvej.intellij
+
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+import org.assertj.core.api.Assertions.assertThat
+
+class ApproveJPropertiesCompletionTest : LightJavaCodeInsightFixtureTestCase() {
+
+  fun testKeyCompletion() {
+    myFixture.configureByText("approvej.properties", "<caret>")
+    val completions = myFixture.completeBasic()
+    val keys = completions.map { it.lookupString }
+    assertThat(keys)
+      .contains(
+        "defaultPrintFormat",
+        "defaultFileReviewer",
+        "reviewerScript",
+        "reviewerAiCommand",
+        "inventoryEnabled",
+        "defaultInlineValueReviewer",
+        "defaultFileReviewerScript",
+      )
+  }
+
+  fun testKeyCompletion_prefix() {
+    myFixture.configureByText("approvej.properties", "default<caret>")
+    val completions = myFixture.completeBasic()
+    val keys = completions.map { it.lookupString }
+    assertThat(keys)
+      .contains("defaultPrintFormat", "defaultFileReviewer", "defaultInlineValueReviewer")
+    assertThat(keys).doesNotContain("reviewerScript", "inventoryEnabled")
+  }
+
+  fun testValueCompletion_printFormat() {
+    myFixture.configureByText("approvej.properties", "defaultPrintFormat = <caret>")
+    val completions = myFixture.completeBasic()
+    val values = completions.map { it.lookupString }
+    assertThat(values).contains("singleLineString", "multiLineString", "json", "yaml")
+  }
+
+  fun testValueCompletion_fileReviewer() {
+    myFixture.configureByText("approvej.properties", "defaultFileReviewer = <caret>")
+    val completions = myFixture.completeBasic()
+    val values = completions.map { it.lookupString }
+    assertThat(values).contains("none", "automatic", "script", "ai")
+  }
+
+  fun testValueCompletion_inventoryEnabled() {
+    myFixture.configureByText("approvej.properties", "inventoryEnabled = <caret>")
+    val completions = myFixture.completeBasic()
+    val values = completions.map { it.lookupString }
+    assertThat(values).contains("true", "false")
+  }
+
+  fun testValueCompletion_freeFormKey() {
+    myFixture.configureByText("approvej.properties", "reviewerScript = <caret>")
+    val completions = myFixture.completeBasic()
+    assertThat(completions).isNullOrEmpty()
+  }
+
+  fun testWrongFileName() {
+    myFixture.configureByText("other.properties", "<caret>")
+    val completions = myFixture.completeBasic()
+    val keys = completions?.map { it.lookupString } ?: emptyList()
+    assertThat(keys).doesNotContain("defaultPrintFormat")
+  }
+}

--- a/plugins/approvej-intellij-plugin/src/test/kotlin/org/approvej/intellij/ApproveJPropertiesInspectionTest.kt
+++ b/plugins/approvej-intellij-plugin/src/test/kotlin/org/approvej/intellij/ApproveJPropertiesInspectionTest.kt
@@ -1,0 +1,74 @@
+package org.approvej.intellij
+
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+
+class ApproveJPropertiesInspectionTest : LightJavaCodeInsightFixtureTestCase() {
+
+  override fun setUp() {
+    super.setUp()
+    myFixture.enableInspections(ApproveJPropertiesInspection())
+  }
+
+  fun testKnownKey() {
+    doHighlightTest("defaultPrintFormat = json")
+  }
+
+  fun testKnownKey_inventoryEnabled() {
+    doHighlightTest("inventoryEnabled = true")
+  }
+
+  fun testAllKnownKeys() {
+    doHighlightTest(
+      """
+      defaultPrintFormat = singleLineString
+      defaultFileReviewer = none
+      reviewerScript = idea diff
+      reviewerAiCommand = claude -p
+      inventoryEnabled = false
+      defaultInlineValueReviewer = automatic
+      """
+        .trimIndent()
+    )
+  }
+
+  fun testUnknownKey() {
+    doHighlightTest(
+      "<warning descr=\"Unknown ApproveJ property key 'misspelledKey'\">misspelledKey</warning> = json"
+    )
+  }
+
+  fun testUnknownKey_similar_to_valid() {
+    doHighlightTest(
+      "<warning descr=\"Unknown ApproveJ property key 'defaultprintformat'\">defaultprintformat</warning> = json"
+    )
+  }
+
+  fun testDeprecatedKey() {
+    doHighlightTest(
+      "<warning descr=\"'defaultFileReviewerScript' is deprecated." +
+        " Use 'defaultFileReviewer = script' and 'reviewerScript = ...' instead.\">" +
+        "defaultFileReviewerScript</warning> = someScript.sh"
+    )
+  }
+
+  fun testMixedKeys() {
+    doHighlightTest(
+      """
+      defaultPrintFormat = json
+      <warning descr="Unknown ApproveJ property key 'typo'">typo</warning> = value
+      <warning descr="'defaultFileReviewerScript' is deprecated. Use 'defaultFileReviewer = script' and 'reviewerScript = ...' instead.">defaultFileReviewerScript</warning> = script.sh
+      """
+        .trimIndent()
+    )
+  }
+
+  fun testWrongFileName() {
+    myFixture.configureByText("other.properties", "misspelledKey = json")
+    myFixture.checkHighlighting()
+  }
+
+  private fun doHighlightTest(content: String) {
+    myFixture.configureByText("approvej.properties", content)
+    myFixture.checkHighlighting()
+  }
+}


### PR DESCRIPTION
## Summary

- Adds editing support for `approvej.properties` files in the IntelliJ plugin
- Warns on unknown/misspelled property keys and marks `defaultFileReviewerScript` as deprecated (strikethrough)
- Provides autocompletion for property keys and their known values (e.g., `json`, `yaml`, `none`, `automatic`)
- Suppresses false "unused property" warnings from the built-in Properties inspection via `ImplicitPropertyUsageProvider`

Closes #285

## Test plan

- [x] All existing and new plugin tests pass (`./gradlew :plugins:approvej-intellij-plugin:check`)
- [x] Manually verified in IntelliJ sandbox (`runIde`)