### PR TITLE
Find test method via enclosing method for lambdas

### DIFF
--- a/modules/core/src/main/java/org/approvej/approve/StackTraceTestFinderUtil.java
+++ b/modules/core/src/main/java/org/approvej/approve/StackTraceTestFinderUtil.java
@@ -32,10 +32,17 @@ public class StackTraceTestFinderUtil {
         .flatMap(
             element -> {
               try {
+                Class<?> clazz = Class.forName(element.getClassName());
                 String methodName =
-                    element.getMethodName().replaceAll("^lambda\\$([^$]+)\\$\\d$", "$1");
-                return stream(Class.forName(element.getClassName()).getDeclaredMethods())
-                    .filter(method -> method.getName().equals(methodName));
+                    element.getMethodName().replaceAll("^lambda\\$([^$]+)\\$\\d+$", "$1");
+                Stream<Method> directMethods =
+                    stream(clazz.getDeclaredMethods())
+                        .filter(method -> method.getName().equals(methodName));
+                Method enclosingMethod = clazz.getEnclosingMethod();
+                if (enclosingMethod != null) {
+                  return Stream.concat(directMethods, Stream.of(enclosingMethod));
+                }
+                return directMethods;
               } catch (NoClassDefFoundError | ClassNotFoundException e) {
                 return Stream.empty();
               }

--- a/modules/core/src/test/java/org/approvej/approve/StackTraceTestFinderUtilTest.java
+++ b/modules/core/src/test/java/org/approvej/approve/StackTraceTestFinderUtilTest.java
@@ -11,6 +11,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -51,6 +52,34 @@ class StackTraceTestFinderUtilTest {
     assertThat(currentTestMethod.method()).isEqualTo(thisMethod);
     assertThat(currentTestMethod.testClass()).isEqualTo(thisMethod.getDeclaringClass());
     assertThat(currentTestMethod.testCaseName()).isEqualTo(thisMethod.getName());
+  }
+
+  @Test
+  void currentTestMethod_called_from_kotlin_like_lambda_on_separate_thread() throws Exception {
+    // Simulates Awaitility's untilAsserted with a Kotlin lambda:
+    // - Awaitility runs the assertion on a polling thread (test method not in stack trace)
+    // - Kotlin lambda compiles to anonymous class (no lambda$ method name pattern)
+    AtomicReference<TestMethod> result = new AtomicReference<>();
+    AtomicReference<Throwable> error = new AtomicReference<>();
+
+    Thread thread =
+        new Thread(
+            new Runnable() {
+              @Override
+              public void run() {
+                try {
+                  result.set(StackTraceTestFinderUtil.currentTestMethod());
+                } catch (Throwable throwable) {
+                  error.set(throwable);
+                }
+              }
+            });
+    thread.start();
+    thread.join();
+
+    assertThat(error.get()).isNull();
+    assertThat(result.get().testCaseName())
+        .isEqualTo("currentTestMethod_called_from_kotlin_like_lambda_on_separate_thread");
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Fix `StackTraceTestFinderUtil.currentTestMethod()` failing when called from a Kotlin lambda on a separate thread (e.g. Awaitility's `untilAsserted`)
- Fall back to `Class.getEnclosingMethod()` when the stack frame's class is an anonymous/inner class, resolving the test method from its enclosing context
- Fix lambda name regex to support multi-digit indices (`\d` → `\d+`)

Closes #98

## Test plan

- [x] New test `currentTestMethod_called_from_kotlin_like_lambda_on_separate_thread` reproduces the bug and passes with the fix
- [x] All existing `StackTraceTestFinderUtilTest` tests still pass