### PR TITLE
Run approvej Gradle tasks against all test task classpaths

### DIFF
--- a/manual/src/docs/asciidoc/chapters/08-build-plugins.adoc
+++ b/manual/src/docs/asciidoc/chapters/08-build-plugins.adoc
@@ -32,6 +32,9 @@ plugins {
 
 NOTE: The plugin requires the Java plugin to be applied in the same project.
 
+The tasks run against the combined classpath of all of the project's test tasks, so they work no matter which source set holds your approval tests -- for example a dedicated `integrationTest` `JvmTestSuite`.
+No extra configuration is needed.
+
 
 [id=build_plugins_setup_maven]
 === Maven Plugin

--- a/plugins/approvej-gradle-plugin/src/main/java/org/approvej/gradle/ApproveJPlugin.java
+++ b/plugins/approvej-gradle-plugin/src/main/java/org/approvej/gradle/ApproveJPlugin.java
@@ -1,15 +1,26 @@
 package org.approvej.gradle;
 
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.List;
+import java.util.concurrent.Callable;
+import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.JavaExec;
-import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.testing.Test;
 
 /** Gradle plugin that registers tasks to manage approved files. */
 @SuppressWarnings("unused")
 public final class ApproveJPlugin implements Plugin<Project> {
+
+  private static final String CLI_MAIN_CLASS = "org.approvej.approve.ApprovedFileInventoryCli";
+
+  private static final String CLI_RESOURCE = "org/approvej/approve/ApprovedFileInventoryCli.class";
 
   record TaskDefinition(String name, String description, String arg) {}
 
@@ -30,12 +41,17 @@ public final class ApproveJPlugin implements Plugin<Project> {
         .withType(
             JavaPlugin.class,
             javaPlugin -> {
-              var testClasspath =
-                  project
-                      .getExtensions()
-                      .getByType(SourceSetContainer.class)
-                      .getByName("test")
-                      .getRuntimeClasspath();
+              // Combine the classpaths of every Test task. Gradle runs a source set's tests via a
+              // Test task, so this resolves the inventory CLI and every recorded test class no
+              // matter which source set holds the approval tests (e.g. a custom integrationTest
+              // JvmTestSuite), without relying on source set naming conventions.
+              FileCollection inventoryClasspath =
+                  project.files(
+                      (Callable<List<FileCollection>>)
+                          () ->
+                              project.getTasks().withType(Test.class).stream()
+                                  .map(Test::getClasspath)
+                                  .toList());
 
               TASK_DEFINITIONS.forEach(
                   definition ->
@@ -47,11 +63,38 @@ public final class ApproveJPlugin implements Plugin<Project> {
                               task -> {
                                 task.setGroup("verification");
                                 task.setDescription(definition.description());
-                                task.setClasspath(testClasspath);
-                                task.getMainClass()
-                                    .set("org.approvej.approve.ApprovedFileInventoryCli");
+                                task.setClasspath(inventoryClasspath);
+                                task.getMainClass().set(CLI_MAIN_CLASS);
                                 task.args(definition.arg());
+                                task.doFirst(unused -> verifyCliOnClasspath(inventoryClasspath));
                               }));
             });
+  }
+
+  /**
+   * Fails fast with an actionable message when the inventory CLI is not on the resolved classpath,
+   * instead of surfacing a raw {@link ClassNotFoundException} from the forked JVM.
+   */
+  private static void verifyCliOnClasspath(FileCollection classpath) {
+    URL[] urls = classpath.getFiles().stream().map(ApproveJPlugin::toUrl).toArray(URL[]::new);
+    try (URLClassLoader loader = new URLClassLoader(urls, null)) {
+      if (loader.findResource(CLI_RESOURCE) == null) {
+        throw new GradleException(
+            ("ApproveJ's inventory CLI (%s) was not found on the classpath of any Test task. Add"
+                    + " the org.approvej:core dependency to the source set that runs your approval"
+                    + " tests.")
+                .formatted(CLI_MAIN_CLASS));
+      }
+    } catch (IOException exception) {
+      throw new GradleException("Failed to inspect the ApproveJ inventory classpath", exception);
+    }
+  }
+
+  private static URL toUrl(java.io.File file) {
+    try {
+      return file.toURI().toURL();
+    } catch (MalformedURLException exception) {
+      throw new GradleException("Failed to resolve classpath entry %s".formatted(file), exception);
+    }
   }
 }

--- a/plugins/approvej-gradle-plugin/src/test/java/org/approvej/gradle/ApproveJPluginTest.java
+++ b/plugins/approvej-gradle-plugin/src/test/java/org/approvej/gradle/ApproveJPluginTest.java
@@ -78,6 +78,27 @@ class ApproveJPluginTest {
   }
 
   @Test
+  void apply_classpath_unions_all_test_tasks() {
+    Project project = ProjectBuilder.builder().build();
+    project.getPluginManager().apply("java");
+    project.getPluginManager().apply(ApproveJPlugin.class);
+    var testTask = (org.gradle.api.tasks.testing.Test) project.getTasks().getByName("test");
+    var integrationTest =
+        project
+            .getTasks()
+            .create(
+                "integrationTest",
+                org.gradle.api.tasks.testing.Test.class,
+                task -> task.setClasspath(project.files("integration-classes")));
+
+    var task = (JavaExec) project.getTasks().getByName("approvejFindLeftovers");
+
+    assertThat(task.getClasspath().getFiles())
+        .containsAll(testTask.getClasspath().getFiles())
+        .containsAll(integrationTest.getClasspath().getFiles());
+  }
+
+  @Test
   void apply_functional() throws IOException {
     Files.writeString(
         tempProjectDir.resolve("build.gradle"),
@@ -100,6 +121,31 @@ class ApproveJPluginTest {
         .contains("approvejCleanup - Detect and remove leftover approved files")
         .contains("approvejApproveAll - Approve all unapproved files")
         .contains("approvejReviewUnapproved - Review all unapproved files");
+  }
+
+  @Test
+  void apply_functional_missing_core_dependency() throws IOException {
+    Files.writeString(
+        tempProjectDir.resolve("build.gradle"),
+        """
+        plugins {
+          id 'java'
+          id 'org.approvej'
+        }
+        repositories { mavenCentral() }
+        """);
+
+    var result =
+        GradleRunner.create()
+            .withProjectDir(tempProjectDir.toFile())
+            .withPluginClasspath()
+            .withArguments("approvejFindLeftovers")
+            .buildAndFail();
+
+    assertThat(result.getOutput())
+        .contains("was not found on the classpath of any Test task")
+        .contains("org.approvej:core")
+        .doesNotContain("ClassNotFoundException");
   }
 
   @Test


### PR DESCRIPTION
Fixes #325.

## Problem

The Gradle plugin hardcoded the `test` source set's runtime classpath when wiring its inventory CLI tasks (`ApproveJPlugin.java:33-38`). Projects whose approval tests live in another source set (e.g. a custom `integrationTest` `JvmTestSuite`) hit two issues:

1. **`ClassNotFoundException`** — `org.approvej:core` isn't on `test`'s classpath, so `ApprovedFileInventoryCli` never loads.
2. **Data loss** — forcing `core` onto `test` to get past (1) lets the CLI run, but it then reflects over `test`, can't see the test class that owns a valid approved file, and reports it as a leftover. `approvejCleanup` would then **delete a valid snapshot**.

## Fix

Build the inventory classpath from the **union of every `Test` task's classpath** instead of one hardcoded source set:

- Uses Gradle's enforced model (a source set is "a test source set" when a `Test` task runs it) rather than source-set naming conventions.
- Covers the built-in `test` task and any `JvmTestSuite` (e.g. `integrationTest`) automatically; a plain source set with no test task is correctly excluded.
- Relies only on stable API (`Test` / `Test.getClasspath()`), not the incubating `TestingExtension`/`JvmTestSuite` types.
- The classpath is exactly the runtime classpath used to execute those tests, so it always contains `org.approvej:core` and the recorded test classes.

Also **fails fast** with an actionable message when the inventory CLI isn't on the resolved classpath, instead of surfacing a raw `ClassNotFoundException` from the forked JVM.

## Notes

No new configuration surface — this is zero-config.

The issue's deeper "guard `approvejCleanup` against unresolvable inventory entries" idea (core-side, in `ApprovedFileInventory`) is intentionally **not** included here; the fail-fast classpath check covers the common destructive path. Happy to follow up separately if wanted.

## Tests

- `apply_classpath_unions_all_test_tasks` — the built-in `test` task and an added `integrationTest` `Test` task both contribute to the task classpath.
- `apply_functional_missing_core_dependency` — a project without `core` fails with the actionable message and no raw `ClassNotFoundException`.
- `./gradlew :plugins:approvej-gradle-plugin:check` passes.

Manual updated (`08-build-plugins.adoc`) to note the tasks run against all test tasks' combined classpath with no extra config.