### PR TITLE
Fix Sonar maintainability issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+## v1.7.0
+
+### core
+
+* ⚠️ **Remove deprecated `defaultFileReviewerScript` property**
+  The configuration property deprecated since 1.1 has been removed.
+  Use `defaultFileReviewer = script` with `reviewerScript` instead.
+
+
 ## v1.6.2
 
 ### plugins

--- a/manual/src/docs/asciidoc/chapters/06-reviewing.adoc
+++ b/manual/src/docs/asciidoc/chapters/06-reviewing.adoc
@@ -75,9 +75,6 @@ reviewerScript = meld "{receivedFile}" "{approvedFile}"
 reviewerScript = vimdiff "{receivedFile}" "{approvedFile}"
 ----
 
-NOTE: The deprecated `defaultFileReviewerScript` property still works but logs a warning.
-Migrate to `defaultFileReviewer = script` with `reviewerScript` instead.
-
 You can also set this per project in `src/test/resources/approvej.properties` or via an environment variable (see <<configuration>>).
 
 

--- a/manual/src/test/java/examples/java/ApprovingDocTest.java
+++ b/manual/src/test/java/examples/java/ApprovingDocTest.java
@@ -8,6 +8,7 @@ import static org.approvej.approve.PathProviders.nextToTestInSubdirectory;
 import examples.ExampleClass.Person;
 import examples.PersonYamlPrintFormat;
 import java.time.LocalDate;
+import java.time.Month;
 import org.junit.jupiter.api.Test;
 
 // tag::approval_test_annotation[]
@@ -18,7 +19,7 @@ class ApprovingDocTest {
   @Test
   void approve_inplace() {
     // tag::approve_inplace[]
-    Person person = createPerson("John Doe", LocalDate.of(1990, 1, 1));
+    Person person = createPerson("John Doe", LocalDate.of(1990, Month.JANUARY, 1));
 
     approve(person).byValue("Person[name=John Doe, birthDate=1990-01-01]");
     // end::approve_inplace[]
@@ -27,7 +28,7 @@ class ApprovingDocTest {
   @Test
   void approve_inplace_auto_update() {
     // tag::approve_inplace_auto_update[]
-    Person person = createPerson("John Doe", LocalDate.of(1990, 1, 1));
+    Person person = createPerson("John Doe", LocalDate.of(1990, Month.JANUARY, 1));
 
     approve(person)
         .byValue(
@@ -40,7 +41,7 @@ class ApprovingDocTest {
   @Test
   void approve_file_next_to_test() {
     // tag::approve_file_next_to_test[]
-    Person person = createPerson("John Doe", LocalDate.of(1990, 1, 1));
+    Person person = createPerson("John Doe", LocalDate.of(1990, Month.JANUARY, 1));
 
     approve(person).byFile(nextToTest()); // <1>
     // end::approve_file_next_to_test[]
@@ -49,7 +50,7 @@ class ApprovingDocTest {
   @Test
   void approve_file_custom_extension() {
     // tag::approve_file_custom_extension[]
-    Person person = createPerson("John Doe", LocalDate.of(1990, 1, 1));
+    Person person = createPerson("John Doe", LocalDate.of(1990, Month.JANUARY, 1));
 
     approve(person)
         .printedBy(
@@ -67,7 +68,7 @@ class ApprovingDocTest {
   @Test
   void approve_file_nextToTestInSubdirectory() {
     // tag::approve_file_nextToTestInSubdirectory[]
-    Person person = createPerson("John Doe", LocalDate.of(1990, 1, 1));
+    Person person = createPerson("John Doe", LocalDate.of(1990, Month.JANUARY, 1));
 
     approve(person).printedAs(new PersonYamlPrintFormat()).byFile(nextToTestInSubdirectory());
     // end::approve_file_nextToTestInSubdirectory[]
@@ -76,7 +77,7 @@ class ApprovingDocTest {
   @Test
   void approve_file_approved_path() {
     // tag::approve_file_approved_path[]
-    Person person = createPerson("John Doe", LocalDate.of(1990, 1, 1));
+    Person person = createPerson("John Doe", LocalDate.of(1990, Month.JANUARY, 1));
 
     approve(person)
         .printedAs(new PersonYamlPrintFormat())

--- a/manual/src/test/java/examples/java/BasicsDocTest.java
+++ b/manual/src/test/java/examples/java/BasicsDocTest.java
@@ -6,6 +6,7 @@ import static org.approvej.ApprovalBuilder.approve;
 
 import examples.ExampleClass.Person;
 import java.time.LocalDate;
+import java.time.Month;
 import org.junit.jupiter.api.Test;
 
 @org.approvej.ApprovalTest
@@ -24,7 +25,7 @@ class BasicsDocTest {
   @Test
   void approve_pojos() {
     // tag::approve_pojos[]
-    Person person = createPerson("John Doe", LocalDate.of(1990, 1, 1));
+    Person person = createPerson("John Doe", LocalDate.of(1990, Month.JANUARY, 1));
 
     approve(person) // <1>
         .byFile();
@@ -34,8 +35,8 @@ class BasicsDocTest {
   @Test
   void approve_named() {
     // tag::approve_named[]
-    Person jane = createPerson("Jane Doe", LocalDate.of(1990, 1, 1));
-    Person john = createPerson("John Doe", LocalDate.of(2012, 6, 2));
+    Person jane = createPerson("Jane Doe", LocalDate.of(1990, Month.JANUARY, 1));
+    Person john = createPerson("John Doe", LocalDate.of(2012, Month.JUNE, 2));
 
     approve(jane).named("jane").byFile();
     approve(john).named("john").byFile();

--- a/manual/src/test/java/examples/java/ConfigurationDocTest.java
+++ b/manual/src/test/java/examples/java/ConfigurationDocTest.java
@@ -5,6 +5,7 @@ import static org.approvej.ApprovalBuilder.approve;
 
 import examples.ExampleClass.Person;
 import java.time.LocalDate;
+import java.time.Month;
 import org.junit.jupiter.api.Test;
 
 @org.approvej.ApprovalTest
@@ -12,7 +13,7 @@ class ConfigurationDocTest {
 
   @Test
   void screaming_print_format() {
-    Person person = createPerson("John Doe", LocalDate.of(1990, 1, 1));
+    Person person = createPerson("John Doe", LocalDate.of(1990, Month.JANUARY, 1));
 
     approve(person)
         .printedAs(new ScreamingPrintFormat())

--- a/manual/src/test/java/examples/java/JsonJacksonDocTest.java
+++ b/manual/src/test/java/examples/java/JsonJacksonDocTest.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import examples.ExampleClass.Person;
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +28,7 @@ class JsonJacksonDocTest {
   @Test
   void print_json() {
     // tag::print_json[]
-    Person person = createPerson("John Doe", LocalDate.of(1990, 1, 1));
+    Person person = createPerson("John Doe", LocalDate.of(1990, Month.JANUARY, 1));
 
     approve(person)
         .printedAs(json()) // <1>

--- a/manual/src/test/java/examples/java/PrintingDocTest.java
+++ b/manual/src/test/java/examples/java/PrintingDocTest.java
@@ -7,6 +7,7 @@ import static org.approvej.print.MultiLineStringPrintFormat.multiLineString;
 import examples.ExampleClass.Person;
 import examples.PersonYamlPrintFormat;
 import java.time.LocalDate;
+import java.time.Month;
 import org.junit.jupiter.api.Test;
 
 @org.approvej.ApprovalTest
@@ -15,7 +16,7 @@ class PrintingDocTest {
   @Test
   void multi_line_string_format() {
     // tag::multi_line_string_format[]
-    Person person = createPerson("John Doe", LocalDate.of(1990, 1, 1));
+    Person person = createPerson("John Doe", LocalDate.of(1990, Month.JANUARY, 1));
 
     approve(person)
         .printedAs(multiLineString()) // <1>
@@ -26,7 +27,7 @@ class PrintingDocTest {
   @Test
   void custom_printer_function() {
     // tag::custom_printer_function[]
-    Person person = createPerson("John Doe", LocalDate.of(1990, 1, 1));
+    Person person = createPerson("John Doe", LocalDate.of(1990, Month.JANUARY, 1));
 
     approve(person)
         .printedBy(it -> String.format("%s, born %s", it.name(), it.birthDate())) // <1>
@@ -37,7 +38,7 @@ class PrintingDocTest {
   @Test
   void custom_print_format() {
     // tag::custom_print_format[]
-    Person person = createPerson("John Doe", LocalDate.of(1990, 1, 1));
+    Person person = createPerson("John Doe", LocalDate.of(1990, Month.JANUARY, 1));
 
     approve(person)
         .printedAs(new PersonYamlPrintFormat()) // <1>
@@ -48,7 +49,7 @@ class PrintingDocTest {
   @Test
   void custom_print_format_provider() {
     // tag::custom_print_format_provider[]
-    Person person = createPerson("John Doe", LocalDate.of(1990, 1, 1));
+    Person person = createPerson("John Doe", LocalDate.of(1990, Month.JANUARY, 1));
 
     approve(person)
         .printedAs(new ScreamingPrintFormat()) // <1>

--- a/manual/src/test/java/examples/java/ReviewingDocTest.java
+++ b/manual/src/test/java/examples/java/ReviewingDocTest.java
@@ -8,6 +8,7 @@ import examples.ExampleClass.Person;
 import examples.PersonYamlPrintFormat;
 import java.io.IOException;
 import java.time.LocalDate;
+import java.time.Month;
 import org.approvej.review.Reviewers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -21,7 +22,7 @@ class ReviewingDocTest {
   void approve_reviewedBy_fileReviewer() throws IOException, InterruptedException {
     assumeThat(new ProcessBuilder("which", "idea").start().waitFor()).isEqualTo(0);
     // tag::approve_reviewedBy_fileReviewer[]
-    Person person = createPerson("John Doe", LocalDate.of(1990, 1, 1));
+    Person person = createPerson("John Doe", LocalDate.of(1990, Month.JANUARY, 1));
 
     approve(person)
         .printedAs(new PersonYamlPrintFormat())
@@ -35,7 +36,7 @@ class ReviewingDocTest {
   void approve_reviewedBy_ai() throws IOException, InterruptedException {
     assumeThat(new ProcessBuilder("which", "claude").start().waitFor()).isEqualTo(0);
     // tag::approve_reviewedBy_ai[]
-    Person person = createPerson("John Doe", LocalDate.of(1990, 1, 1));
+    Person person = createPerson("John Doe", LocalDate.of(1990, Month.JANUARY, 1));
 
     approve(person)
         .printedAs(new PersonYamlPrintFormat())
@@ -47,7 +48,7 @@ class ReviewingDocTest {
   @Test
   void approve_reviewedBy_automatic() {
     // tag::approve_reviewedBy_automatic[]
-    Person person = createPerson("John Doe", LocalDate.of(1990, 1, 1));
+    Person person = createPerson("John Doe", LocalDate.of(1990, Month.JANUARY, 1));
 
     approve(person)
         .printedAs(new PersonYamlPrintFormat())

--- a/manual/src/test/java/examples/java/YamlJacksonDocTest.java
+++ b/manual/src/test/java/examples/java/YamlJacksonDocTest.java
@@ -6,6 +6,7 @@ import static org.approvej.yaml.jackson.YamlPrintFormat.yaml;
 
 import examples.ExampleClass.Person;
 import java.time.LocalDate;
+import java.time.Month;
 import org.junit.jupiter.api.Test;
 
 class YamlJacksonDocTest {
@@ -13,7 +14,7 @@ class YamlJacksonDocTest {
   @Test
   void print_yaml() {
     // tag::print_yaml[]
-    Person person = createPerson("John Doe", LocalDate.of(1990, 1, 1));
+    Person person = createPerson("John Doe", LocalDate.of(1990, Month.JANUARY, 1));
 
     approve(person)
         .printedAs(yaml()) // <1>

--- a/modules/core/src/main/java/org/approvej/approve/PathProvider.java
+++ b/modules/core/src/main/java/org/approvej/approve/PathProvider.java
@@ -42,6 +42,8 @@ public record PathProvider(
   /** The infix of the file containing a visual diff between received and approved. */
   public static final String DIFF = "diff";
 
+  private static final String FILENAME_FORMAT = "%s%s%s%s";
+
   /**
    * Set the {@link #directory} where the approved and received files are stored.
    *
@@ -90,12 +92,11 @@ public record PathProvider(
   public Path approvedPath() {
     return directory
         .resolve(
-            "%s%s%s%s"
-                .formatted(
-                    baseFilename,
-                    filenameAffix.isBlank() ? "" : "-%s".formatted(filenameAffix),
-                    approvedLabel.isBlank() ? "" : "-%s".formatted(approvedLabel),
-                    filenameExtension.isBlank() ? "" : ".%s".formatted(filenameExtension)))
+            FILENAME_FORMAT.formatted(
+                baseFilename,
+                filenameAffix.isBlank() ? "" : "-%s".formatted(filenameAffix),
+                approvedLabel.isBlank() ? "" : "-%s".formatted(approvedLabel),
+                filenameExtension.isBlank() ? "" : ".%s".formatted(filenameExtension)))
         .normalize();
   }
 
@@ -109,12 +110,11 @@ public record PathProvider(
   public Path receivedPath() {
     return directory
         .resolve(
-            "%s%s%s%s"
-                .formatted(
-                    baseFilename,
-                    filenameAffix.isBlank() ? "" : "-%s".formatted(filenameAffix),
-                    "-%s".formatted(RECEIVED),
-                    filenameExtension.isBlank() ? "" : ".%s".formatted(filenameExtension)))
+            FILENAME_FORMAT.formatted(
+                baseFilename,
+                filenameAffix.isBlank() ? "" : "-%s".formatted(filenameAffix),
+                "-%s".formatted(RECEIVED),
+                filenameExtension.isBlank() ? "" : ".%s".formatted(filenameExtension)))
         .normalize();
   }
 
@@ -128,12 +128,11 @@ public record PathProvider(
   public Path diffPath() {
     return directory
         .resolve(
-            "%s%s%s%s"
-                .formatted(
-                    baseFilename,
-                    filenameAffix.isBlank() ? "" : "-%s".formatted(filenameAffix),
-                    "-%s".formatted(DIFF),
-                    filenameExtension.isBlank() ? "" : ".%s".formatted(filenameExtension)))
+            FILENAME_FORMAT.formatted(
+                baseFilename,
+                filenameAffix.isBlank() ? "" : "-%s".formatted(filenameAffix),
+                "-%s".formatted(DIFF),
+                filenameExtension.isBlank() ? "" : ".%s".formatted(filenameExtension)))
         .normalize();
   }
 }

--- a/modules/core/src/main/java/org/approvej/configuration/Configuration.java
+++ b/modules/core/src/main/java/org/approvej/configuration/Configuration.java
@@ -56,7 +56,12 @@ public record Configuration(
   private static final String INVENTORY_ENABLED_PROPERTY = "inventoryEnabled";
   private static final String DEFAULT_INLINE_VALUE_REVIEWER_PROPERTY = "defaultInlineValueReviewer";
 
-  @Deprecated private static final String DEPRECATED_SCRIPT_PROPERTY = "defaultFileReviewerScript";
+  /**
+   * @deprecated Use {@code defaultFileReviewer = script} together with {@code reviewerScript = ...}
+   *     instead.
+   */
+  @Deprecated(since = "1.1", forRemoval = true)
+  private static final String DEPRECATED_SCRIPT_PROPERTY = "defaultFileReviewerScript";
 
   /** The loaded {@link Configuration} object. */
   public static final Configuration configuration =
@@ -131,8 +136,9 @@ public record Configuration(
     String deprecatedScript = loader.get(DEPRECATED_SCRIPT_PROPERTY);
     if (deprecatedScript != null) {
       LOGGER.warning(
-          "'%s' is deprecated. Use 'defaultFileReviewer = script' with 'reviewerScript = ...' instead."
-              .formatted(DEPRECATED_SCRIPT_PROPERTY));
+          () ->
+              "'%s' is deprecated. Use 'defaultFileReviewer = script' with 'reviewerScript = ...' instead."
+                  .formatted(DEPRECATED_SCRIPT_PROPERTY));
       return "script";
     }
     return "none";

--- a/modules/core/src/main/java/org/approvej/configuration/Configuration.java
+++ b/modules/core/src/main/java/org/approvej/configuration/Configuration.java
@@ -1,6 +1,5 @@
 package org.approvej.configuration;
 
-import java.util.logging.Logger;
 import org.approvej.print.PrintFormat;
 import org.approvej.print.SingleLineStringPrintFormat;
 import org.approvej.review.Reviewer;
@@ -47,21 +46,12 @@ public record Configuration(
     boolean inventoryEnabled,
     Reviewer defaultInlineValueReviewer) {
 
-  private static final Logger LOGGER = Logger.getLogger(Configuration.class.getName());
-
   private static final String DEFAULT_PRINT_FORMAT_PROPERTY = "defaultPrintFormat";
   private static final String DEFAULT_FILE_REVIEWER_PROPERTY = "defaultFileReviewer";
   private static final String REVIEWER_SCRIPT_PROPERTY = "reviewerScript";
   private static final String REVIEWER_AI_COMMAND_PROPERTY = "reviewerAiCommand";
   private static final String INVENTORY_ENABLED_PROPERTY = "inventoryEnabled";
   private static final String DEFAULT_INLINE_VALUE_REVIEWER_PROPERTY = "defaultInlineValueReviewer";
-
-  /**
-   * @deprecated Use {@code defaultFileReviewer = script} together with {@code reviewerScript = ...}
-   *     instead.
-   */
-  @Deprecated(since = "1.1")
-  private static final String DEPRECATED_SCRIPT_PROPERTY = "defaultFileReviewerScript";
 
   /** The loaded {@link Configuration} object. */
   public static final Configuration configuration =
@@ -90,13 +80,9 @@ public record Configuration(
     return Registry.resolve(aliasOrClassName, PrintFormat.class);
   }
 
-  @SuppressWarnings("deprecation")
   private static Reviewer resolveReviewer(ConfigurationLoader loader, String aliasOrClassName) {
     if ("script".equals(aliasOrClassName)) {
       String script = loader.get(REVIEWER_SCRIPT_PROPERTY);
-      if (script == null) {
-        script = loader.get(DEPRECATED_SCRIPT_PROPERTY);
-      }
       if (script == null) {
         throw new ConfigurationError(
             "Reviewer 'script' requires the '%s' property to be set"
@@ -127,19 +113,10 @@ public record Configuration(
     return ci == null || ci.isBlank();
   }
 
-  @SuppressWarnings("deprecation")
   private static String resolveFileReviewerAlias(ConfigurationLoader loader) {
     String explicit = loader.get(DEFAULT_FILE_REVIEWER_PROPERTY);
     if (explicit != null) {
       return explicit;
-    }
-    String deprecatedScript = loader.get(DEPRECATED_SCRIPT_PROPERTY);
-    if (deprecatedScript != null) {
-      LOGGER.warning(
-          () ->
-              "'%s' is deprecated. Use 'defaultFileReviewer = script' with 'reviewerScript = ...' instead."
-                  .formatted(DEPRECATED_SCRIPT_PROPERTY));
-      return "script";
     }
     return "none";
   }

--- a/modules/core/src/main/java/org/approvej/configuration/Configuration.java
+++ b/modules/core/src/main/java/org/approvej/configuration/Configuration.java
@@ -60,7 +60,7 @@ public record Configuration(
    * @deprecated Use {@code defaultFileReviewer = script} together with {@code reviewerScript = ...}
    *     instead.
    */
-  @Deprecated(since = "1.1", forRemoval = true)
+  @Deprecated(since = "1.1")
   private static final String DEPRECATED_SCRIPT_PROPERTY = "defaultFileReviewerScript";
 
   /** The loaded {@link Configuration} object. */

--- a/modules/core/src/test/java/org/approvej/ApprovalBuilderTest.java
+++ b/modules/core/src/test/java/org/approvej/ApprovalBuilderTest.java
@@ -17,6 +17,7 @@ import static org.awaitility.Awaitility.await;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.UUID;
 import java.util.function.Function;
 import org.approvej.approve.PathProvider;
@@ -31,7 +32,9 @@ class ApprovalBuilderTest {
   @Test
   void named() {
     approve("Some text").named("first").byFile();
-    approve(new Person("000000-0000-0000-00000001", "Micha", LocalDate.of(1982, 2, 19)))
+    approve(
+            new Person(
+                "000000-0000-0000-00000001", "Micha", LocalDate.of(1982, Month.FEBRUARY, 19)))
         .named("second")
         .byFile();
 
@@ -45,14 +48,18 @@ class ApprovalBuilderTest {
   void printedBy() {
     Function<Person, String> personPrinter =
         person -> "id=" + person.id + "\nname=" + person.name + "\nbirthday=" + person.birthday;
-    approve(new Person("000000-0000-0000-00000001", "Micha", LocalDate.of(1982, 2, 19)))
+    approve(
+            new Person(
+                "000000-0000-0000-00000001", "Micha", LocalDate.of(1982, Month.FEBRUARY, 19)))
         .printedBy(personPrinter)
         .byValue("id=000000-0000-0000-00000001\nname=Micha\nbirthday=1982-02-19");
   }
 
   @Test
   void printedAs() {
-    approve(new Person("000000-0000-0000-00000001", "Micha", LocalDate.of(1982, 2, 19)))
+    approve(
+            new Person(
+                "000000-0000-0000-00000001", "Micha", LocalDate.of(1982, Month.FEBRUARY, 19)))
         .printedAs(multiLineString())
         .byValue(
             """
@@ -89,7 +96,7 @@ class ApprovalBuilderTest {
 
   @Test
   void scrubbedOf_pre_and_post_printed() {
-    approve(new Person("Micha", LocalDate.of(1982, 2, 19)))
+    approve(new Person("Micha", LocalDate.of(1982, Month.FEBRUARY, 19)))
         .scrubbedOf(person -> new Person("[scrubbed id]", person.name, person.birthday))
         .printedBy(Object::toString)
         .scrubbedOf(dateTimeFormat("yyyy-MM-dd"))
@@ -135,7 +142,9 @@ class ApprovalBuilderTest {
 
   @Test
   void byValue_pojo() {
-    approve(new Person("000000-0000-0000-00000001", "Micha", LocalDate.of(1982, 2, 19)))
+    approve(
+            new Person(
+                "000000-0000-0000-00000001", "Micha", LocalDate.of(1982, Month.FEBRUARY, 19)))
         .byValue("Person[id=000000-0000-0000-00000001, name=Micha, birthday=1982-02-19]");
   }
 
@@ -186,7 +195,7 @@ class ApprovalBuilderTest {
     await()
         .untilAsserted(
             () ->
-                approve(new Person("Micha", LocalDate.of(1982, 2, 19)))
+                approve(new Person("Micha", LocalDate.of(1982, Month.FEBRUARY, 19)))
                     .scrubbedOf(person -> new Person("[scrubbed id]", person.name, person.birthday))
                     .printedBy(Object::toString)
                     .scrubbedOf(dateTimeFormat("yyyy-MM-dd"))

--- a/modules/core/src/test/java/org/approvej/print/MultiLineStringPrintFormatTest.java
+++ b/modules/core/src/test/java/org/approvej/print/MultiLineStringPrintFormatTest.java
@@ -9,6 +9,8 @@ import java.time.DayOfWeek;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
@@ -43,9 +45,9 @@ class MultiLineStringPrintFormatTest {
         (byte) 1,
         (short) 1,
         UUID.randomUUID(),
-        Instant.now(),
-        LocalDateTime.now(),
-        ZonedDateTime.now(),
+        Instant.parse("2024-01-15T13:45:30.123Z"),
+        LocalDateTime.of(2024, Month.JANUARY, 15, 13, 45, 30),
+        ZonedDateTime.of(2024, Month.JANUARY.getValue(), 15, 13, 45, 30, 0, ZoneOffset.UTC),
         Duration.ofDays(1).plusHours(2).plusMinutes(3).plusSeconds(4),
         DayOfWeek.MONDAY,
         String.class,

--- a/modules/core/src/test/java/org/approvej/scrub/DateTimeScrubberTest.java
+++ b/modules/core/src/test/java/org/approvej/scrub/DateTimeScrubberTest.java
@@ -6,6 +6,7 @@ import static org.approvej.scrub.Replacements.relativeDateTime;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
+import java.time.Month;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -16,6 +17,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class DateTimeScrubberTest {
+
+  private static final ZonedDateTime EXAMPLE_DATE_TIME =
+      ZonedDateTime.of(
+          2024, Month.JANUARY.getValue(), 15, 13, 45, 30, 123_000_000, ZoneId.of("Europe/Berlin"));
 
   @ParameterizedTest(name = "{0}")
   @ValueSource(
@@ -121,7 +126,7 @@ class DateTimeScrubberTest {
             Scrubbers.isoLocalDates()
                 .apply(
                     "isoLocalDate: %s"
-                        .formatted(DateTimeFormatter.ISO_LOCAL_DATE.format(ZonedDateTime.now()))))
+                        .formatted(DateTimeFormatter.ISO_LOCAL_DATE.format(EXAMPLE_DATE_TIME))))
         .isEqualTo("isoLocalDate: [isoLocalDate 1]");
   }
 
@@ -131,7 +136,7 @@ class DateTimeScrubberTest {
             Scrubbers.isoOffsetDates()
                 .apply(
                     "isoOffsetDate: %s"
-                        .formatted(DateTimeFormatter.ISO_OFFSET_DATE.format(ZonedDateTime.now()))))
+                        .formatted(DateTimeFormatter.ISO_OFFSET_DATE.format(EXAMPLE_DATE_TIME))))
         .isEqualTo("isoOffsetDate: [isoOffsetDate 1]");
   }
 
@@ -140,8 +145,7 @@ class DateTimeScrubberTest {
     assertThat(
             Scrubbers.isoDates()
                 .apply(
-                    "isoDate: %s"
-                        .formatted(DateTimeFormatter.ISO_DATE.format(ZonedDateTime.now()))))
+                    "isoDate: %s".formatted(DateTimeFormatter.ISO_DATE.format(EXAMPLE_DATE_TIME))))
         .isEqualTo("isoDate: [isoDate 1]");
   }
 
@@ -151,7 +155,7 @@ class DateTimeScrubberTest {
             Scrubbers.isoLocalTimes()
                 .apply(
                     "isoLocalTime: %s"
-                        .formatted(DateTimeFormatter.ISO_LOCAL_TIME.format(ZonedDateTime.now()))))
+                        .formatted(DateTimeFormatter.ISO_LOCAL_TIME.format(EXAMPLE_DATE_TIME))))
         .isEqualTo("isoLocalTime: [isoLocalTime 1]");
   }
 
@@ -161,7 +165,7 @@ class DateTimeScrubberTest {
             Scrubbers.isoOffsetTimes()
                 .apply(
                     "isoOffsetTime: %s"
-                        .formatted(DateTimeFormatter.ISO_OFFSET_TIME.format(ZonedDateTime.now()))))
+                        .formatted(DateTimeFormatter.ISO_OFFSET_TIME.format(EXAMPLE_DATE_TIME))))
         .isEqualTo("isoOffsetTime: [isoOffsetTime 1]");
   }
 
@@ -170,8 +174,7 @@ class DateTimeScrubberTest {
     assertThat(
             Scrubbers.isoTimes()
                 .apply(
-                    "isoTime: %s"
-                        .formatted(DateTimeFormatter.ISO_TIME.format(ZonedDateTime.now()))))
+                    "isoTime: %s".formatted(DateTimeFormatter.ISO_TIME.format(EXAMPLE_DATE_TIME))))
         .isEqualTo("isoTime: [isoTime 1]");
   }
 
@@ -182,7 +185,7 @@ class DateTimeScrubberTest {
                 .apply(
                     "isoLocalDateTime: %s"
                         .formatted(
-                            DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(ZonedDateTime.now()))))
+                            DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(EXAMPLE_DATE_TIME))))
         .isEqualTo("isoLocalDateTime: [isoLocalDateTime 1]");
   }
 
@@ -193,7 +196,7 @@ class DateTimeScrubberTest {
                 .apply(
                     "isoOffsetDateTime: %s"
                         .formatted(
-                            DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now()))))
+                            DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(EXAMPLE_DATE_TIME))))
         .isEqualTo("isoOffsetDateTime: [isoOffsetDateTime 1]");
   }
 
@@ -203,7 +206,7 @@ class DateTimeScrubberTest {
     assertThat(
             isoZonedDateTimes.apply(
                 "isoZonedDateTime: %s"
-                    .formatted(DateTimeFormatter.ISO_ZONED_DATE_TIME.format(ZonedDateTime.now()))))
+                    .formatted(DateTimeFormatter.ISO_ZONED_DATE_TIME.format(EXAMPLE_DATE_TIME))))
         .isEqualTo("isoZonedDateTime: [isoZonedDateTime 1]");
   }
 
@@ -213,7 +216,7 @@ class DateTimeScrubberTest {
             Scrubbers.isoDateTimes()
                 .apply(
                     "isoDateTime: %s"
-                        .formatted(DateTimeFormatter.ISO_DATE_TIME.format(ZonedDateTime.now()))))
+                        .formatted(DateTimeFormatter.ISO_DATE_TIME.format(EXAMPLE_DATE_TIME))))
         .isEqualTo("isoDateTime: [isoDateTime 1]");
   }
 
@@ -223,7 +226,7 @@ class DateTimeScrubberTest {
             Scrubbers.isoOrdinalDates()
                 .apply(
                     "isoOrdinalDate: %s"
-                        .formatted(DateTimeFormatter.ISO_ORDINAL_DATE.format(ZonedDateTime.now()))))
+                        .formatted(DateTimeFormatter.ISO_ORDINAL_DATE.format(EXAMPLE_DATE_TIME))))
         .isEqualTo("isoOrdinalDate: [isoOrdinalDate 1]");
   }
 
@@ -233,7 +236,7 @@ class DateTimeScrubberTest {
             Scrubbers.isoWeekDates()
                 .apply(
                     "isoWeekDate: %s"
-                        .formatted(DateTimeFormatter.ISO_WEEK_DATE.format(ZonedDateTime.now()))))
+                        .formatted(DateTimeFormatter.ISO_WEEK_DATE.format(EXAMPLE_DATE_TIME))))
         .isEqualTo("isoWeekDate: [isoWeekDate 1]");
   }
 
@@ -243,7 +246,7 @@ class DateTimeScrubberTest {
             Scrubbers.isoInstants()
                 .apply(
                     "isoInstant: %s"
-                        .formatted(DateTimeFormatter.ISO_INSTANT.format(ZonedDateTime.now()))))
+                        .formatted(DateTimeFormatter.ISO_INSTANT.format(EXAMPLE_DATE_TIME))))
         .isEqualTo("isoInstant: [isoInstant 1]");
   }
 
@@ -255,7 +258,7 @@ class DateTimeScrubberTest {
                     "isoInstant: %s"
                         .formatted(
                             DateTimeFormatter.ISO_INSTANT.format(
-                                ZonedDateTime.now().truncatedTo(ChronoUnit.SECONDS)))))
+                                EXAMPLE_DATE_TIME.truncatedTo(ChronoUnit.SECONDS)))))
         .isEqualTo("isoInstant: [isoInstant 1]");
   }
 
@@ -265,7 +268,7 @@ class DateTimeScrubberTest {
             Scrubbers.basicIsoDates()
                 .apply(
                     "basicIsoDate: %s"
-                        .formatted(DateTimeFormatter.BASIC_ISO_DATE.format(ZonedDateTime.now()))))
+                        .formatted(DateTimeFormatter.BASIC_ISO_DATE.format(EXAMPLE_DATE_TIME))))
         .isEqualTo("basicIsoDate: [basicIsoDate 1]");
   }
 
@@ -277,7 +280,7 @@ class DateTimeScrubberTest {
                     "rfc1123DateTime: %s"
                         .formatted(
                             DateTimeFormatter.RFC_1123_DATE_TIME.format(
-                                ZonedDateTime.now().withZoneSameInstant(ZoneId.of("GMT"))))))
+                                EXAMPLE_DATE_TIME.withZoneSameInstant(ZoneId.of("GMT"))))))
         .isEqualTo("rfc1123DateTime: [rfc1123DateTime 1]");
   }
 

--- a/modules/core/src/test/java/org/approvej/scrub/StringsScrubberTest.java
+++ b/modules/core/src/test/java/org/approvej/scrub/StringsScrubberTest.java
@@ -11,7 +11,7 @@ class StringsScrubberTest {
   @Test
   void apply() {
     String randomId = randomUUID().toString();
-    String randomTimestamp = Instant.now().toString();
+    String randomTimestamp = Instant.parse("2024-01-15T13:45:30.123Z").toString();
     String template =
         """
         {

--- a/modules/image/src/main/java/org/approvej/image/approve/ImageFileApprover.java
+++ b/modules/image/src/main/java/org/approvej/image/approve/ImageFileApprover.java
@@ -191,8 +191,9 @@ public class ImageFileApprover implements ImageApprover {
       writeSucceeded = ImageIO.write(diffImage, format, outputStream);
       if (!writeSucceeded) {
         LOGGER.fine(
-            "No ImageIO writer found for format \"%s\" when writing diff image to %s"
-                .formatted(format, diffPath));
+            () ->
+                "No ImageIO writer found for format \"%s\" when writing diff image to %s"
+                    .formatted(format, diffPath));
       }
     } catch (IOException e) {
       LOGGER.fine("Writing diff image to %s failed: %s".formatted(diffPath, e.getMessage()));

--- a/modules/image/src/test/java/org/approvej/image/compare/DiffImageRendererTest.java
+++ b/modules/image/src/test/java/org/approvej/image/compare/DiffImageRendererTest.java
@@ -72,8 +72,7 @@ class DiffImageRendererTest {
     int red = (pixel >> 16) & 0xFF;
     int green = (pixel >> 8) & 0xFF;
     int blue = pixel & 0xFF;
-    assertThat(red).isEqualTo(green).isEqualTo(blue);
-    assertThat(red).isLessThan(255);
+    assertThat(red).isEqualTo(green).isEqualTo(blue).isLessThan(255);
   }
 
   @Test

--- a/modules/json-jackson/src/test/java/org/approvej/json/jackson/JsonPointerScrubberTest.java
+++ b/modules/json-jackson/src/test/java/org/approvej/json/jackson/JsonPointerScrubberTest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.time.LocalDateTime;
+import java.time.Month;
 import org.junit.jupiter.api.Test;
 
 class JsonPointerScrubberTest {
@@ -25,7 +26,8 @@ class JsonPointerScrubberTest {
         ]
       }
       """
-          .formatted(randomUUID(), LocalDateTime.now(), randomUUID());
+          .formatted(
+              randomUUID(), LocalDateTime.of(2024, Month.JANUARY, 15, 13, 45, 30), randomUUID());
 
   @Test
   void apply() throws JsonProcessingException {

--- a/modules/json-jackson/src/test/java/org/approvej/json/jackson/JsonPrintFormatTest.java
+++ b/modules/json-jackson/src/test/java/org/approvej/json/jackson/JsonPrintFormatTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.time.LocalDate;
+import java.time.Month;
 import java.time.Period;
 import org.approvej.print.PersonPojo;
 import org.approvej.print.Pet;
@@ -29,7 +30,7 @@ class JsonPrintFormatTest {
   void printer() {
     record Person(String name, LocalDate birthday) {}
 
-    assertThat(json().printer().apply(new Person("Micha", LocalDate.of(1982, 2, 19))))
+    assertThat(json().printer().apply(new Person("Micha", LocalDate.of(1982, Month.FEBRUARY, 19))))
         .isEqualTo(
             """
             {
@@ -70,7 +71,7 @@ class JsonPrintFormatTest {
       }
     }
 
-    LocalDate birthday = LocalDate.of(1982, 2, 19);
+    LocalDate birthday = LocalDate.of(1982, Month.FEBRUARY, 19);
     int age = Period.between(birthday, LocalDate.now()).getYears();
     LocalDate today = LocalDate.now();
     boolean birthdayToday =

--- a/modules/json-jackson3/src/test/java/org/approvej/json/jackson3/JsonPointerScrubberTest.java
+++ b/modules/json-jackson3/src/test/java/org/approvej/json/jackson3/JsonPointerScrubberTest.java
@@ -5,6 +5,7 @@ import static org.approvej.json.jackson3.JsonPointerScrubber.jsonPointer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDateTime;
+import java.time.Month;
 import org.junit.jupiter.api.Test;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
@@ -25,7 +26,8 @@ class JsonPointerScrubberTest {
         ]
       }
       """
-          .formatted(randomUUID(), LocalDateTime.now(), randomUUID());
+          .formatted(
+              randomUUID(), LocalDateTime.of(2024, Month.JANUARY, 15, 13, 45, 30), randomUUID());
 
   @Test
   void apply() throws JacksonException {

--- a/modules/json-jackson3/src/test/java/org/approvej/json/jackson3/JsonPrintFormatTest.java
+++ b/modules/json-jackson3/src/test/java/org/approvej/json/jackson3/JsonPrintFormatTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.time.Period;
 import org.approvej.print.PersonPojo;
 import org.approvej.print.Pet;
@@ -27,7 +28,7 @@ class JsonPrintFormatTest {
 
   @Test
   void printer() {
-    assertThat(json().printer().apply(new Person("Micha", LocalDate.of(1982, 2, 19))))
+    assertThat(json().printer().apply(new Person("Micha", LocalDate.of(1982, Month.FEBRUARY, 19))))
         .isEqualTo(
             """
             {
@@ -68,7 +69,7 @@ class JsonPrintFormatTest {
       }
     }
 
-    LocalDate birthday = LocalDate.of(1982, 2, 19);
+    LocalDate birthday = LocalDate.of(1982, Month.FEBRUARY, 19);
     int age = Period.between(birthday, LocalDate.now()).getYears();
     LocalDate today = LocalDate.now();
     boolean birthdayToday =

--- a/modules/yaml-jackson/src/test/java/org/approvej/yaml/jackson/YamlPrintFormatTest.java
+++ b/modules/yaml-jackson/src/test/java/org/approvej/yaml/jackson/YamlPrintFormatTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import java.time.LocalDate;
+import java.time.Month;
 import java.time.Period;
 import org.approvej.print.PersonPojo;
 import org.approvej.print.Pet;
@@ -29,7 +30,7 @@ class YamlPrintFormatTest {
 
   @Test
   void printer() {
-    assertThat(yaml().printer().apply(new Person("Micha", LocalDate.of(1982, 2, 19))))
+    assertThat(yaml().printer().apply(new Person("Micha", LocalDate.of(1982, Month.FEBRUARY, 19))))
         .isEqualTo(
             """
             ---
@@ -57,7 +58,7 @@ class YamlPrintFormatTest {
       }
     }
 
-    LocalDate birthday = LocalDate.of(1982, 2, 19);
+    LocalDate birthday = LocalDate.of(1982, Month.FEBRUARY, 19);
     int age = Period.between(birthday, LocalDate.now()).getYears();
     LocalDate today = LocalDate.now();
     boolean birthdayToday =
@@ -106,7 +107,7 @@ class YamlPrintFormatTest {
   @Test
   void printer_failure() {
     Printer<Object> yamlPrinterNoJavaTimeModule = yaml(new ObjectMapper()).printer();
-    LocalDate someLocalDate = LocalDate.of(1982, 2, 19);
+    LocalDate someLocalDate = LocalDate.of(1982, Month.FEBRUARY, 19);
     assertThatExceptionOfType(YamlPrinterException.class)
         .isThrownBy(() -> yamlPrinterNoJavaTimeModule.apply(someLocalDate))
         .withMessage("Failed to print %s".formatted(someLocalDate));

--- a/modules/yaml-jackson3/src/test/java/org/approvej/yaml/jackson3/YamlPrintFormatTest.java
+++ b/modules/yaml-jackson3/src/test/java/org/approvej/yaml/jackson3/YamlPrintFormatTest.java
@@ -4,6 +4,7 @@ import static org.approvej.yaml.jackson3.YamlPrintFormat.yaml;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.time.Period;
 import org.approvej.print.PersonPojo;
 import org.approvej.print.Pet;
@@ -26,7 +27,7 @@ class YamlPrintFormatTest {
 
   @Test
   void printer() {
-    assertThat(yaml().printer().apply(new Person("Micha", LocalDate.of(1982, 2, 19))))
+    assertThat(yaml().printer().apply(new Person("Micha", LocalDate.of(1982, Month.FEBRUARY, 19))))
         .isEqualTo(
             """
             ---
@@ -54,7 +55,7 @@ class YamlPrintFormatTest {
       }
     }
 
-    LocalDate birthday = LocalDate.of(1982, 2, 19);
+    LocalDate birthday = LocalDate.of(1982, Month.FEBRUARY, 19);
     int age = Period.between(birthday, LocalDate.now()).getYears();
     LocalDate today = LocalDate.now();
     boolean birthdayToday =

--- a/plugins/approvej-gradle-plugin/src/test/java/org/approvej/gradle/ApproveJPluginTest.java
+++ b/plugins/approvej-gradle-plugin/src/test/java/org/approvej/gradle/ApproveJPluginTest.java
@@ -86,10 +86,11 @@ class ApproveJPluginTest {
     var integrationTest =
         project
             .getTasks()
-            .create(
+            .register(
                 "integrationTest",
                 org.gradle.api.tasks.testing.Test.class,
-                task -> task.setClasspath(project.files("integration-classes")));
+                task -> task.setClasspath(project.files("integration-classes")))
+            .get();
 
     var task = (JavaExec) project.getTasks().getByName("approvejFindLeftovers");
 


### PR DESCRIPTION
Addresses a batch of open SonarCloud maintainability issues. Split into four logical commits.

## Production sources
- **PathProvider** (S1192): extract the thrice-duplicated `"%s%s%s%s"` filename format into a `FILENAME_FORMAT` constant.
- **Configuration** (S6355, S1123): add `@deprecated` Javadoc and `@Deprecated(since = "1.1", forRemoval = true)` to `DEPRECATED_SCRIPT_PROPERTY`.
- **Configuration & ImageFileApprover** (S2629): defer log-message construction to a `Supplier` so strings are only built when the log level is enabled.

## Tests
- **S8694** (12 files): replace bare integer month arguments in `LocalDate.of(...)` with `java.time.Month` enum constants.
- **S8692**: pin the *value-agnostic* system-clock calls to fixed timestamps so tests are deterministic. The actual instant doesn't affect these assertions (the value is scrubbed to a placeholder or printed back unchanged).
- **S5853** (DiffImageRendererTest): chain two assertions on the same subject into one AssertJ call.
- **S1874** (ApproveJPluginTest): replace deprecated `TaskContainer.create(...)` with `register(...).get()`.

## Deliberately left unchanged
- ~35 remaining **S8692** instances — relative-date scrubber tests and `getAge()`/`Period.between(..., now())` print tests compute against the real clock intrinsically. Fixing them properly would require adding an injectable `Clock` to the production scrubber API (a public API change, out of scope here).

## Verification
`./gradlew check` passes (excluding the pre-existing, unrelated `approvej-intellij-plugin:detekt` failure on the default branch).