### PR TITLE
Fix Gradle 9.6 deprecation warnings in build scripts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,8 +28,8 @@ subprojects {
           create<MavenPublication>(name) {
             from(components.findByName("java") ?: components.getByName("javaPlatform"))
             pom {
-              project.properties["mavenPomName"]?.let { name = "$it" }
-              project.properties["mavenPomDescription"]?.let { description = "$it" }
+              project.findProperty("mavenPomName")?.let { name = "$it" }
+              project.findProperty("mavenPomDescription")?.let { description = "$it" }
               url = "https://approvej.org"
               inceptionYear = "2025"
               licenses {
@@ -183,25 +183,24 @@ spotless {
   freshmark { target("*.md") }
 }
 
-val updatePages by
-  tasks.registering(Sync::class) {
-    group = "documentation"
-    description = "Assembles the website with manual and Javadoc"
+tasks.register<Sync>("updatePages") {
+  group = "documentation"
+  description = "Assembles the website with manual and Javadoc"
 
-    into(layout.buildDirectory.dir("pages"))
+  into(layout.buildDirectory.dir("pages"))
 
-    // Favicon and logo
-    from("favicon.png") { into("img") }
-    from("logo.svg") { into("img") }
+  // Favicon and logo
+  from("favicon.png") { into("img") }
+  from("logo.svg") { into("img") }
 
-    // AsciiDoc manual
-    from(project(":manual").tasks.named("asciidoctor"))
+  // AsciiDoc manual
+  from(project(":manual").tasks.named("asciidoctor"))
 
-    // Cheat sheet PDF
-    from(project(":manual").tasks.named("cheatSheetPdf")) { into("pdf") }
+  // Cheat sheet PDF
+  from(project(":manual").tasks.named("cheatSheetPdf")) { into("pdf") }
 
-    // Javadoc for each module
-    project(":modules").subprojects.forEach { module ->
-      from(module.tasks.named("javadoc")) { into("javadoc/${module.name}") }
-    }
+  // Javadoc for each module
+  project(":modules").subprojects.forEach { module ->
+    from(module.tasks.named("javadoc")) { into("javadoc/${module.name}") }
   }
+}

--- a/manual/build.gradle.kts
+++ b/manual/build.gradle.kts
@@ -13,7 +13,7 @@ java { toolchain { languageVersion.set(JavaLanguageVersion.of(21)) } }
 
 repositories { mavenCentral() }
 
-val asciidoctorExt: Configuration by configurations.creating
+val asciidoctorExt: Configuration = configurations.create("asciidoctorExt")
 
 dependencies {
   asciidoctorExt(libs.asciidoctor.block.switch)
@@ -22,35 +22,34 @@ dependencies {
 
 testing {
   suites {
-    val test by
-      getting(JvmTestSuite::class) {
-        useJUnitJupiter()
-        dependencies {
-          implementation(project(":modules:core"))
-          implementation(project(":modules:image"))
-          implementation(project(":modules:json-jackson"))
-          implementation(project(":modules:yaml-jackson"))
-          implementation(project(":modules:http"))
-          implementation(project(":modules:database-jdbc"))
+    getByName<JvmTestSuite>("test") {
+      useJUnitJupiter()
+      dependencies {
+        implementation(project(":modules:core"))
+        implementation(project(":modules:image"))
+        implementation(project(":modules:json-jackson"))
+        implementation(project(":modules:yaml-jackson"))
+        implementation(project(":modules:http"))
+        implementation(project(":modules:database-jdbc"))
 
-          implementation(platform(libs.jackson2.bom))
-          implementation(libs.playwright)
-          implementation(libs.selenium)
+        implementation(platform(libs.jackson2.bom))
+        implementation(libs.playwright)
+        implementation(libs.selenium)
 
-          implementation(libs.jackson2.databind)
-          implementation(libs.h2)
-          implementation(libs.jackson2.dataformat.yaml)
-          implementation(libs.jackson2.jsr310)
+        implementation(libs.jackson2.databind)
+        implementation(libs.h2)
+        implementation(libs.jackson2.dataformat.yaml)
+        implementation(libs.jackson2.jsr310)
 
-          implementation(platform(libs.junit.bom))
-          implementation(libs.junit.jupiter.api)
-          implementation(libs.junit.jupiter.params)
-          implementation(libs.assertj.core)
+        implementation(platform(libs.junit.bom))
+        implementation(libs.junit.jupiter.api)
+        implementation(libs.junit.jupiter.params)
+        implementation(libs.assertj.core)
 
-          runtimeOnly(libs.junit.platform.launcher)
-          runtimeOnly(libs.junit.jupiter.engine)
-        }
+        runtimeOnly(libs.junit.platform.launcher)
+        runtimeOnly(libs.junit.jupiter.engine)
       }
+    }
   }
 }
 

--- a/modules/core/build.gradle.kts
+++ b/modules/core/build.gradle.kts
@@ -26,37 +26,34 @@ dependencies {
 
 testing {
   suites {
-    val test by
-      getting(JvmTestSuite::class) {
-        useJUnitJupiter()
-        dependencies {
-          implementation(platform(libs.junit.bom))
-          implementation(libs.junit.jupiter.api)
-          implementation(libs.junit.jupiter.params)
-          implementation(libs.assertj.core)
-          implementation(libs.awaitility)
+    getByName<JvmTestSuite>("test") {
+      useJUnitJupiter()
+      dependencies {
+        implementation(platform(libs.junit.bom))
+        implementation(libs.junit.jupiter.api)
+        implementation(libs.junit.jupiter.params)
+        implementation(libs.assertj.core)
+        implementation(libs.awaitility)
 
-          runtimeOnly(libs.junit.platform.launcher)
-          runtimeOnly(libs.junit.jupiter.engine)
-        }
+        runtimeOnly(libs.junit.platform.launcher)
+        runtimeOnly(libs.junit.jupiter.engine)
       }
-    val testng by
-      registering(JvmTestSuite::class) {
-        useTestNG()
-        dependencies {
-          implementation(libs.testng)
-          implementation(project())
-        }
+    }
+    register<JvmTestSuite>("testng") {
+      useTestNG()
+      dependencies {
+        implementation(libs.testng)
+        implementation(project())
       }
-    val spock by
-      registering(JvmTestSuite::class) {
-        useSpock()
-        dependencies {
-          implementation(libs.spock)
-          implementation(libs.groovy)
-          implementation(project())
-        }
+    }
+    register<JvmTestSuite>("spock") {
+      useSpock()
+      dependencies {
+        implementation(libs.spock)
+        implementation(libs.groovy)
+        implementation(project())
       }
+    }
   }
 }
 

--- a/modules/database-jdbc/build.gradle.kts
+++ b/modules/database-jdbc/build.gradle.kts
@@ -22,20 +22,19 @@ dependencies {
 
 testing {
   suites {
-    val test by
-      getting(JvmTestSuite::class) {
-        useJUnitJupiter()
-        dependencies {
-          implementation(platform(libs.junit.bom))
-          implementation(libs.junit.jupiter.api)
-          implementation(libs.junit.jupiter.params)
-          implementation(libs.assertj.core)
-          implementation(libs.h2)
+    getByName<JvmTestSuite>("test") {
+      useJUnitJupiter()
+      dependencies {
+        implementation(platform(libs.junit.bom))
+        implementation(libs.junit.jupiter.api)
+        implementation(libs.junit.jupiter.params)
+        implementation(libs.assertj.core)
+        implementation(libs.h2)
 
-          runtimeOnly(libs.junit.platform.launcher)
-          runtimeOnly(libs.junit.jupiter.engine)
-        }
+        runtimeOnly(libs.junit.platform.launcher)
+        runtimeOnly(libs.junit.jupiter.engine)
       }
+    }
   }
 }
 

--- a/modules/http-wiremock/build.gradle.kts
+++ b/modules/http-wiremock/build.gradle.kts
@@ -24,21 +24,20 @@ dependencies {
 
 testing {
   suites {
-    val test by
-      getting(JvmTestSuite::class) {
-        useJUnitJupiter()
-        dependencies {
-          implementation(libs.wiremock)
+    getByName<JvmTestSuite>("test") {
+      useJUnitJupiter()
+      dependencies {
+        implementation(libs.wiremock)
 
-          implementation(platform(libs.junit.bom))
-          implementation(libs.junit.jupiter.api)
-          implementation(libs.junit.jupiter.params)
-          implementation(libs.assertj.core)
+        implementation(platform(libs.junit.bom))
+        implementation(libs.junit.jupiter.api)
+        implementation(libs.junit.jupiter.params)
+        implementation(libs.assertj.core)
 
-          runtimeOnly(libs.junit.platform.launcher)
-          runtimeOnly(libs.junit.jupiter.engine)
-        }
+        runtimeOnly(libs.junit.platform.launcher)
+        runtimeOnly(libs.junit.jupiter.engine)
       }
+    }
   }
 }
 

--- a/modules/http/build.gradle.kts
+++ b/modules/http/build.gradle.kts
@@ -22,19 +22,18 @@ dependencies {
 
 testing {
   suites {
-    val test by
-      getting(JvmTestSuite::class) {
-        useJUnitJupiter()
-        dependencies {
-          implementation(platform(libs.junit.bom))
-          implementation(libs.junit.jupiter.api)
-          implementation(libs.junit.jupiter.params)
-          implementation(libs.assertj.core)
+    getByName<JvmTestSuite>("test") {
+      useJUnitJupiter()
+      dependencies {
+        implementation(platform(libs.junit.bom))
+        implementation(libs.junit.jupiter.api)
+        implementation(libs.junit.jupiter.params)
+        implementation(libs.assertj.core)
 
-          runtimeOnly(libs.junit.platform.launcher)
-          runtimeOnly(libs.junit.jupiter.engine)
-        }
+        runtimeOnly(libs.junit.platform.launcher)
+        runtimeOnly(libs.junit.jupiter.engine)
       }
+    }
   }
 }
 

--- a/modules/image/build.gradle.kts
+++ b/modules/image/build.gradle.kts
@@ -22,19 +22,18 @@ dependencies {
 
 testing {
   suites {
-    val test by
-      getting(JvmTestSuite::class) {
-        useJUnitJupiter()
-        dependencies {
-          implementation(platform(libs.junit.bom))
-          implementation(libs.junit.jupiter.api)
-          implementation(libs.junit.jupiter.params)
-          implementation(libs.assertj.core)
+    getByName<JvmTestSuite>("test") {
+      useJUnitJupiter()
+      dependencies {
+        implementation(platform(libs.junit.bom))
+        implementation(libs.junit.jupiter.api)
+        implementation(libs.junit.jupiter.params)
+        implementation(libs.assertj.core)
 
-          runtimeOnly(libs.junit.platform.launcher)
-          runtimeOnly(libs.junit.jupiter.engine)
-        }
+        runtimeOnly(libs.junit.platform.launcher)
+        runtimeOnly(libs.junit.jupiter.engine)
       }
+    }
   }
 }
 

--- a/modules/json-jackson/build.gradle.kts
+++ b/modules/json-jackson/build.gradle.kts
@@ -26,25 +26,24 @@ dependencies {
 
 testing {
   suites {
-    val test by
-      getting(JvmTestSuite::class) {
-        useJUnitJupiter()
-        dependencies {
-          implementation(testFixtures(project(":modules:core")))
+    getByName<JvmTestSuite>("test") {
+      useJUnitJupiter()
+      dependencies {
+        implementation(testFixtures(project(":modules:core")))
 
-          implementation(platform(libs.jackson2.bom))
-          implementation(libs.jackson2.databind)
-          implementation(libs.jackson2.jsr310)
+        implementation(platform(libs.jackson2.bom))
+        implementation(libs.jackson2.databind)
+        implementation(libs.jackson2.jsr310)
 
-          implementation(platform(libs.junit.bom))
-          implementation(libs.junit.jupiter.api)
-          implementation(libs.junit.jupiter.params)
-          implementation(libs.assertj.core)
+        implementation(platform(libs.junit.bom))
+        implementation(libs.junit.jupiter.api)
+        implementation(libs.junit.jupiter.params)
+        implementation(libs.assertj.core)
 
-          runtimeOnly(libs.junit.platform.launcher)
-          runtimeOnly(libs.junit.jupiter.engine)
-        }
+        runtimeOnly(libs.junit.platform.launcher)
+        runtimeOnly(libs.junit.jupiter.engine)
       }
+    }
   }
 }
 

--- a/modules/json-jackson3/build.gradle.kts
+++ b/modules/json-jackson3/build.gradle.kts
@@ -25,24 +25,23 @@ dependencies {
 
 testing {
   suites {
-    val test by
-      getting(JvmTestSuite::class) {
-        useJUnitJupiter()
-        dependencies {
-          implementation(testFixtures(project(":modules:core")))
+    getByName<JvmTestSuite>("test") {
+      useJUnitJupiter()
+      dependencies {
+        implementation(testFixtures(project(":modules:core")))
 
-          implementation(platform(libs.jackson3.bom))
-          implementation(libs.jackson3.databind)
+        implementation(platform(libs.jackson3.bom))
+        implementation(libs.jackson3.databind)
 
-          implementation(platform(libs.junit.bom))
-          implementation(libs.junit.jupiter.api)
-          implementation(libs.junit.jupiter.params)
-          implementation(libs.assertj.core)
+        implementation(platform(libs.junit.bom))
+        implementation(libs.junit.jupiter.api)
+        implementation(libs.junit.jupiter.params)
+        implementation(libs.assertj.core)
 
-          runtimeOnly(libs.junit.platform.launcher)
-          runtimeOnly(libs.junit.jupiter.engine)
-        }
+        runtimeOnly(libs.junit.platform.launcher)
+        runtimeOnly(libs.junit.jupiter.engine)
       }
+    }
   }
 }
 

--- a/modules/yaml-jackson/build.gradle.kts
+++ b/modules/yaml-jackson/build.gradle.kts
@@ -27,26 +27,25 @@ dependencies {
 
 testing {
   suites {
-    val test by
-      getting(JvmTestSuite::class) {
-        useJUnitJupiter()
-        dependencies {
-          implementation(testFixtures(project(":modules:core")))
+    getByName<JvmTestSuite>("test") {
+      useJUnitJupiter()
+      dependencies {
+        implementation(testFixtures(project(":modules:core")))
 
-          implementation(platform(libs.jackson2.bom))
-          implementation(libs.jackson2.databind)
-          implementation(libs.jackson2.dataformat.yaml)
-          implementation(libs.jackson2.jsr310)
+        implementation(platform(libs.jackson2.bom))
+        implementation(libs.jackson2.databind)
+        implementation(libs.jackson2.dataformat.yaml)
+        implementation(libs.jackson2.jsr310)
 
-          implementation(platform(libs.junit.bom))
-          implementation(libs.junit.jupiter.api)
-          implementation(libs.junit.jupiter.params)
-          implementation(libs.assertj.core)
+        implementation(platform(libs.junit.bom))
+        implementation(libs.junit.jupiter.api)
+        implementation(libs.junit.jupiter.params)
+        implementation(libs.assertj.core)
 
-          runtimeOnly(libs.junit.platform.launcher)
-          runtimeOnly(libs.junit.jupiter.engine)
-        }
+        runtimeOnly(libs.junit.platform.launcher)
+        runtimeOnly(libs.junit.jupiter.engine)
       }
+    }
   }
 }
 

--- a/modules/yaml-jackson3/build.gradle.kts
+++ b/modules/yaml-jackson3/build.gradle.kts
@@ -27,26 +27,25 @@ dependencies {
 
 testing {
   suites {
-    val test by
-      getting(JvmTestSuite::class) {
-        useJUnitJupiter()
-        dependencies {
-          implementation(testFixtures(project(":modules:core")))
+    getByName<JvmTestSuite>("test") {
+      useJUnitJupiter()
+      dependencies {
+        implementation(testFixtures(project(":modules:core")))
 
-          // Tests need Jackson
-          implementation(platform(libs.jackson3.bom))
-          implementation(libs.jackson3.databind)
-          implementation(libs.jackson3.dataformat.yaml)
+        // Tests need Jackson
+        implementation(platform(libs.jackson3.bom))
+        implementation(libs.jackson3.databind)
+        implementation(libs.jackson3.dataformat.yaml)
 
-          implementation(platform(libs.junit.bom))
-          implementation(libs.junit.jupiter.api)
-          implementation(libs.junit.jupiter.params)
-          implementation(libs.assertj.core)
+        implementation(platform(libs.junit.bom))
+        implementation(libs.junit.jupiter.api)
+        implementation(libs.junit.jupiter.params)
+        implementation(libs.assertj.core)
 
-          runtimeOnly(libs.junit.platform.launcher)
-          runtimeOnly(libs.junit.jupiter.engine)
-        }
+        runtimeOnly(libs.junit.platform.launcher)
+        runtimeOnly(libs.junit.jupiter.engine)
       }
+    }
   }
 }
 

--- a/plugins/approvej-gradle-plugin/build.gradle.kts
+++ b/plugins/approvej-gradle-plugin/build.gradle.kts
@@ -11,19 +11,18 @@ repositories { mavenCentral() }
 
 testing {
   suites {
-    val test by
-      getting(JvmTestSuite::class) {
-        useJUnitJupiter()
-        dependencies {
-          implementation(platform(libs.junit.bom))
-          implementation(libs.junit.jupiter.api)
-          implementation(libs.junit.jupiter.params)
-          implementation(libs.assertj.core)
+    getByName<JvmTestSuite>("test") {
+      useJUnitJupiter()
+      dependencies {
+        implementation(platform(libs.junit.bom))
+        implementation(libs.junit.jupiter.api)
+        implementation(libs.junit.jupiter.params)
+        implementation(libs.assertj.core)
 
-          runtimeOnly(libs.junit.platform.launcher)
-          runtimeOnly(libs.junit.jupiter.engine)
-        }
+        runtimeOnly(libs.junit.platform.launcher)
+        runtimeOnly(libs.junit.jupiter.engine)
       }
+    }
   }
 }
 

--- a/plugins/approvej-maven-plugin/build.gradle.kts
+++ b/plugins/approvej-maven-plugin/build.gradle.kts
@@ -24,18 +24,17 @@ tasks.jacocoTestReport { reports { xml.required = true } }
 
 testing {
   suites {
-    val test by
-      getting(JvmTestSuite::class) {
-        useJUnitJupiter()
-        dependencies {
-          implementation(platform(libs.junit.bom))
-          implementation(libs.junit.jupiter.api)
-          implementation(libs.junit.jupiter.params)
-          implementation(libs.assertj.core)
+    getByName<JvmTestSuite>("test") {
+      useJUnitJupiter()
+      dependencies {
+        implementation(platform(libs.junit.bom))
+        implementation(libs.junit.jupiter.api)
+        implementation(libs.junit.jupiter.params)
+        implementation(libs.assertj.core)
 
-          runtimeOnly(libs.junit.platform.launcher)
-          runtimeOnly(libs.junit.jupiter.engine)
-        }
+        runtimeOnly(libs.junit.platform.launcher)
+        runtimeOnly(libs.junit.jupiter.engine)
       }
+    }
   }
 }


### PR DESCRIPTION
## What

Removes the Gradle 9.6 deprecation warnings emitted on every build by replacing the deprecated Kotlin DSL delegate APIs and the eager `Project.properties` accessor.

- `val test by getting(JvmTestSuite::class)` → `getByName<JvmTestSuite>("test")` (all modules/plugins)
- `registering(JvmTestSuite::class)` → `register<JvmTestSuite>(...)` for the core `testng` / `spock` suites
- `tasks.registering(Sync::class)` → `tasks.register<Sync>("updatePages")`
- `configurations.creating` → `configurations.create("asciidoctorExt")` in `manual`
- `project.properties[...]` → `project.findProperty(...)`

## Why

Gradle 9.6 deprecated these in favor of the lazy/eager replacements documented in its upgrade guide. The old forms produced many `w:` warnings per build run.

## Verification

- `./gradlew help` now reports zero `w:` build-script warnings
- `./gradlew spotlessKotlinGradleCheck` passes
- `./gradlew check` compiles all modules and runs the core `test` / `testng` / `spock` suites (only the `examples:spring-boot` Testcontainers tests fail locally due to no Docker; unaffected by this change)