### PR TITLE
Add database-spring-boot auto-configuration module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@
   The configuration property deprecated since 1.1 has been removed.
   Use `defaultFileReviewer = script` with `reviewerScript` instead.
 
+### database-spring-boot
+
+* ✨ **New module for Spring Boot database testing**
+  Add `database-spring-boot` module providing a Spring Boot auto-configuration that wraps the Spring-managed `DataSource` with a `RecordingDataSource` automatically.
+  Add the dependency and the injected `DataSource` records SQL out of the box — no `BeanPostProcessor` boilerplate.
+  Recording can be disabled with `approvej.database.recording.enabled=false`.
+  ([#256](https://github.com/mkutz/ApproveJ/issues/256))
+
 
 ## v1.6.2
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,7 @@ It is structured in four main directories:
 - The [modules](modules) directory contains all the published library modules:
   - [core](modules/core) contains the code for the core framework and should not have any dependencies to other modules and only very few (if any) to external libraries,
   - [database-jdbc](modules/database-jdbc) contains the JDBC adapter for database testing,
+  - [database-spring-boot](modules/database-spring-boot) contains the Spring Boot auto-configuration for database testing,
   - [http](modules/http) contains code to create an HTTP server for approving requests,
   - [http-wiremock](modules/http-wiremock) contains the WireMock adapter for HTTP testing,
   - [image](modules/image) contains the image approval and comparison utilities,

--- a/examples/spring-boot/build.gradle.kts
+++ b/examples/spring-boot/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
   testImplementation(project(":modules:yaml-jackson3"))
   testImplementation(project(":modules:http"))
   testImplementation(project(":modules:database-jdbc"))
+  testImplementation(project(":modules:database-spring-boot"))
   testImplementation(platform(libs.jackson3.bom))
   testImplementation(libs.jackson3.dataformat.yaml)
   testImplementation(libs.playwright)

--- a/examples/spring-boot/src/test/java/org/approvej/examples/shop/order/OrderSqlApprovalTest.java
+++ b/examples/spring-boot/src/test/java/org/approvej/examples/shop/order/OrderSqlApprovalTest.java
@@ -17,19 +17,14 @@ import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 
 // tag::spring_boot_database[]
 @SpringBootTest
-@Import(OrderSqlApprovalTest.RecordingDataSourceConfiguration.class) // <1>
 class OrderSqlApprovalTest {
 
   @ServiceConnection
@@ -46,24 +41,7 @@ class OrderSqlApprovalTest {
 
   @Autowired private OrderService orderService;
   @Autowired private ProductRepository productRepository;
-  @Autowired private DataSource dataSource; // <2>
-
-  @TestConfiguration
-  static class RecordingDataSourceConfiguration {
-
-    @Bean
-    static BeanPostProcessor recordingDataSourceWrapper() { // <3>
-      return new BeanPostProcessor() {
-        @Override
-        public Object postProcessAfterInitialization(Object bean, String beanName) {
-          if (bean instanceof DataSource dataSource && !(bean instanceof RecordingDataSource)) {
-            return new RecordingDataSource(dataSource);
-          }
-          return bean;
-        }
-      };
-    }
-  }
+  @Autowired private DataSource dataSource; // <1>
 
   @BeforeEach
   void resetPaymentStub() {
@@ -88,7 +66,7 @@ class OrderSqlApprovalTest {
 
     orderService.placeOrder("Dave", "dave@example.com", List.of(product.getId()));
 
-    approve(recordingDataSource.lastRecordedQuery()) // <4>
+    approve(recordingDataSource.lastRecordedQuery()) // <2>
         .printedAs(sql())
         .scrubbedOf(uuids())
         .byFile();

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,11 +48,13 @@ playwright = { module = "com.microsoft.playwright:playwright", version = "1.60.0
 postgresql = { module = "org.postgresql:postgresql", version = "42.7.11" }
 selenium = { module = "org.seleniumhq.selenium:selenium-java", version = "4.45.0" }
 spock = { module = "org.spockframework:spock-core", version = "2.4-M7-groovy-5.0" }
+spring-boot-autoconfigure = { module = "org.springframework.boot:spring-boot-autoconfigure", version.ref = "spring-boot" }
 spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa", version.ref = "spring-boot" }
 spring-boot-starter-data-jpa-test = { module = "org.springframework.boot:spring-boot-starter-data-jpa-test", version.ref = "spring-boot" }
 spring-boot-starter-thymeleaf = { module = "org.springframework.boot:spring-boot-starter-thymeleaf", version.ref = "spring-boot" }
 spring-boot-starter-webmvc = { module = "org.springframework.boot:spring-boot-starter-webmvc", version.ref = "spring-boot" }
 spring-boot-starter-webmvc-test = { module = "org.springframework.boot:spring-boot-starter-webmvc-test", version.ref = "spring-boot" }
+spring-boot-test = { module = "org.springframework.boot:spring-boot-test", version.ref = "spring-boot" }
 spring-boot-testcontainers = { module = "org.springframework.boot:spring-boot-testcontainers", version.ref = "spring-boot" }
 testcontainers-junit-jupiter = { module = "org.testcontainers:testcontainers-junit-jupiter", version.ref = "testcontainers" }
 testcontainers-postgresql = { module = "org.testcontainers:testcontainers-postgresql", version.ref = "testcontainers" }

--- a/manual/src/docs/asciidoc/chapters/07e-database.adoc
+++ b/manual/src/docs/asciidoc/chapters/07e-database.adoc
@@ -100,18 +100,40 @@ Since `RecordingDataSource` implements `DataSource`, it can be passed anywhere a
 With **plain JDBC**, simply wrap your `DataSource` before passing it to the code under test, as shown in the <<database_approve_sql,basic example>> above.
 
 In a **Spring Boot** test, the `DataSource` is managed by the container and injected into your services automatically.
-The following example from the Spring Boot example project shows a complete test class that wraps the `DataSource` with a `RecordingDataSource` and approves the recorded SQL:
+The `database-spring-boot` module provides an auto-configuration that wraps the Spring-managed `DataSource` with a `RecordingDataSource` for you — no `BeanPostProcessor` or `@TestConfiguration` boilerplate required.
+
+.Gradle
+[source,groovy,subs=attributes+,role="primary"]
+----
+testImplementation 'org.approvej:database-spring-boot:{revnumber}'
+----
+.Gradle.kts
+[source,kotlin,subs=attributes+,role="secondary"]
+----
+testImplementation("org.approvej:database-spring-boot:{revnumber}")
+----
+.Maven
+[source,xml,subs=attributes+,role="secondary"]
+----
+<dependency>
+  <groupId>org.approvej</groupId>
+  <artifactId>database-spring-boot</artifactId>
+  <version>{revnumber}</version>
+  <scope>test</scope>
+</dependency>
+----
+
+With the module on the test classpath, the injected `DataSource` is already a `RecordingDataSource` — inject it, cast it, and approve the recorded SQL:
 
 [source,java,indent=0]
 ----
 include::../../../../../examples/spring-boot/src/test/java/org/approvej/examples/shop/order/OrderSqlApprovalTest.java[tag=spring_boot_database]
 ----
-<1> `@Import` activates the `@TestConfiguration`.
-Without it, the inner class is ignored.
-<2> The injected `DataSource` is now the `RecordingDataSource` wrapper.
-<3> A `BeanPostProcessor` intercepts the `DataSource` bean and wraps it with `RecordingDataSource`.
-This ensures all beans — including your services and JPA — use the recording wrapper transparently.
-<4> Approve the last recorded SQL query using the <<database_sql_print_format,SQL print format>>.
+<1> The injected `DataSource` is the `RecordingDataSource` wrapper, so your services and JPA all record transparently.
+<2> Approve the last recorded SQL query using the <<database_sql_print_format,SQL print format>>.
+
+Recording is enabled by default.
+Set `approvej.database.recording.enabled=false` to disable it for contexts that need the plain `DataSource`.
 
 TIP: Call `resetRecordedQueries()` before exercising the code under test to ensure you only capture the SQL you care about.
 

--- a/modules/database-spring-boot/build.gradle.kts
+++ b/modules/database-spring-boot/build.gradle.kts
@@ -1,0 +1,46 @@
+@file:Suppress("UnstableApiUsage", "unused")
+
+plugins {
+  `java-library`
+  jacoco
+  `jvm-test-suite`
+  `maven-publish`
+}
+
+java {
+  withJavadocJar()
+  withSourcesJar()
+  toolchain { languageVersion.set(JavaLanguageVersion.of(21)) }
+}
+
+repositories { mavenCentral() }
+
+dependencies {
+  api(project(":modules:database-jdbc"))
+  api(libs.jspecify)
+
+  compileOnly(libs.spring.boot.autoconfigure)
+}
+
+testing {
+  suites {
+    getByName<JvmTestSuite>("test") {
+      useJUnitJupiter()
+      dependencies {
+        implementation(libs.spring.boot.autoconfigure)
+        implementation(libs.spring.boot.test)
+        implementation(libs.h2)
+
+        implementation(platform(libs.junit.bom))
+        implementation(libs.junit.jupiter.api)
+        implementation(libs.junit.jupiter.params)
+        implementation(libs.assertj.core)
+
+        runtimeOnly(libs.junit.platform.launcher)
+        runtimeOnly(libs.junit.jupiter.engine)
+      }
+    }
+  }
+}
+
+tasks.jacocoTestReport { reports { xml.required = true } }

--- a/modules/database-spring-boot/gradle.properties
+++ b/modules/database-spring-boot/gradle.properties
@@ -1,0 +1,2 @@
+mavenPomName = ApproveJ Database Spring Boot
+mavenPomDescription = Spring Boot auto-configuration for ApproveJ database testing

--- a/modules/database-spring-boot/src/main/java/org/approvej/database/spring/ApprovejDatabaseAutoConfiguration.java
+++ b/modules/database-spring-boot/src/main/java/org/approvej/database/spring/ApprovejDatabaseAutoConfiguration.java
@@ -1,0 +1,63 @@
+package org.approvej.database.spring;
+
+import javax.sql.DataSource;
+import org.approvej.database.jdbc.RecordingDataSource;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Auto-configuration that wraps every Spring-managed {@link DataSource} with a {@link
+ * RecordingDataSource}, so the SQL your code sends can be approved without any manual wiring.
+ *
+ * <p>Add the {@code database-spring-boot} module to your test dependencies and the {@link
+ * DataSource} injected into your services and repositories becomes a {@link RecordingDataSource}.
+ * Inject it and cast it to access the recorded queries:
+ *
+ * <pre>{@code
+ * @Autowired DataSource dataSource;
+ *
+ * RecordingDataSource recordingDataSource = (RecordingDataSource) dataSource;
+ * }</pre>
+ *
+ * <p>Recording is enabled by default. Set {@code approvej.database.recording.enabled=false} to
+ * disable it, for example in contexts where the plain {@link DataSource} is required.
+ */
+@NullMarked
+@AutoConfiguration
+@ConditionalOnClass({DataSource.class, RecordingDataSource.class})
+@ConditionalOnProperty(
+    name = "approvej.database.recording.enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class ApprovejDatabaseAutoConfiguration {
+
+  /** Creates a new {@link ApprovejDatabaseAutoConfiguration}. */
+  public ApprovejDatabaseAutoConfiguration() {}
+
+  /**
+   * A {@link BeanPostProcessor} that wraps each {@link DataSource} bean with a {@link
+   * RecordingDataSource}, unless it already is one.
+   *
+   * <p>The bean is {@code static} so it is instantiated early enough to post-process the {@link
+   * DataSource} without prematurely initializing other beans.
+   *
+   * @return the {@link BeanPostProcessor} wrapping {@link DataSource} beans
+   */
+  @Bean
+  static BeanPostProcessor recordingDataSourceBeanPostProcessor() {
+    return new BeanPostProcessor() {
+      @Override
+      public @Nullable Object postProcessAfterInitialization(Object bean, String beanName) {
+        if (bean instanceof DataSource dataSource && !(bean instanceof RecordingDataSource)) {
+          return new RecordingDataSource(dataSource);
+        }
+        return bean;
+      }
+    };
+  }
+}

--- a/modules/database-spring-boot/src/main/java/org/approvej/database/spring/ApprovejDatabaseAutoConfiguration.java
+++ b/modules/database-spring-boot/src/main/java/org/approvej/database/spring/ApprovejDatabaseAutoConfiguration.java
@@ -36,8 +36,7 @@ import org.springframework.context.annotation.Bean;
     matchIfMissing = true)
 public class ApprovejDatabaseAutoConfiguration {
 
-  /** Creates a new {@link ApprovejDatabaseAutoConfiguration}. */
-  public ApprovejDatabaseAutoConfiguration() {}
+  ApprovejDatabaseAutoConfiguration() {}
 
   /**
    * A {@link BeanPostProcessor} that wraps each {@link DataSource} bean with a {@link

--- a/modules/database-spring-boot/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/modules/database-spring-boot/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.approvej.database.spring.ApprovejDatabaseAutoConfiguration

--- a/modules/database-spring-boot/src/test/java/org/approvej/database/spring/ApprovejDatabaseAutoConfigurationTest.java
+++ b/modules/database-spring-boot/src/test/java/org/approvej/database/spring/ApprovejDatabaseAutoConfigurationTest.java
@@ -1,0 +1,60 @@
+package org.approvej.database.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import org.approvej.database.jdbc.RecordingDataSource;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+class ApprovejDatabaseAutoConfigurationTest {
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner()
+          .withConfiguration(AutoConfigurations.of(ApprovejDatabaseAutoConfiguration.class))
+          .withUserConfiguration(DataSourceConfiguration.class);
+
+  @Test
+  void recordingDataSourceBeanPostProcessor() {
+    contextRunner.run(
+        context -> {
+          DataSource dataSource = context.getBean(DataSource.class);
+          assertThat(dataSource).isInstanceOf(RecordingDataSource.class);
+
+          try (Connection connection = dataSource.getConnection();
+              Statement statement = connection.createStatement()) {
+            statement.execute("SELECT 1");
+          }
+
+          assertThat(((RecordingDataSource) dataSource).recordedQueries())
+              .containsExactly("SELECT 1");
+        });
+  }
+
+  @Test
+  void recordingDataSourceBeanPostProcessor_disabled() {
+    contextRunner
+        .withPropertyValues("approvej.database.recording.enabled=false")
+        .run(
+            context ->
+                assertThat(context.getBean(DataSource.class))
+                    .isNotInstanceOf(RecordingDataSource.class));
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  static class DataSourceConfiguration {
+
+    @Bean
+    DataSource dataSource() {
+      JdbcDataSource dataSource = new JdbcDataSource();
+      dataSource.setUrl("jdbc:h2:mem:approvej-spring;DB_CLOSE_DELAY=-1");
+      return dataSource;
+    }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,8 @@ include("modules:http-wiremock")
 
 include("modules:database-jdbc")
 
+include("modules:database-spring-boot")
+
 include("plugins:approvej-gradle-plugin")
 
 include("plugins:approvej-maven-plugin")


### PR DESCRIPTION
Closes #256.

## What

A new `database-spring-boot` module providing a Spring Boot auto-configuration that wraps the Spring-managed `DataSource` with a `RecordingDataSource` automatically.

Before, Spring Boot users had to hand-write a `BeanPostProcessor` in a `@TestConfiguration` to enable SQL approval testing:

```java
@TestConfiguration
static class RecordingDataSourceConfiguration {
  @Bean
  static BeanPostProcessor recordingDataSourceWrapper() {
    return new BeanPostProcessor() {
      @Override
      public Object postProcessAfterInitialization(Object bean, String beanName) {
        if (bean instanceof DataSource dataSource && !(bean instanceof RecordingDataSource)) {
          return new RecordingDataSource(dataSource);
        }
        return bean;
      }
    };
  }
}
```

Now adding the dependency is enough — the injected `DataSource` is already a `RecordingDataSource`:

```java
@Autowired private DataSource dataSource;
// ...
RecordingDataSource recordingDataSource = (RecordingDataSource) dataSource;
```

## Details

- `ApprovejDatabaseAutoConfiguration` exposes a `static BeanPostProcessor` that wraps `DataSource` beans, gated by `@ConditionalOnClass` and `@ConditionalOnProperty("approvej.database.recording.enabled", matchIfMissing = true)`.
- Recording is **on by default** (the module is `testImplementation`-scoped, so it never loads in production contexts) and can be disabled with `approvej.database.recording.enabled=false`.
- `compileOnly` on Spring (users bring their own version, mirroring `http-wiremock`).
- Tests use `ApplicationContextRunner` + H2 — no Docker required.
- The `examples/spring-boot` `OrderSqlApprovalTest` is simplified to consume the module (drops the boilerplate).
- Documented in the database manual chapter (`07e-database.adoc`), consistent with how `http-wiremock` is documented inside the HTTP chapter rather than as a standalone chapter.
- BOM picks up the new module automatically; `CHANGELOG.md` and `CONTRIBUTING.md` updated.

## Verification

- `:modules:database-spring-boot:check` — both tests pass.
- `:examples:spring-boot:compileTestJava` compiles (its `@SpringBootTest` run still requires Docker, so not executed here).
- Javadoc builds, manual renders, `spotlessApply` clean.