### PR TITLE
Mark library module classes as @NullMarked

### DIFF
--- a/modules/core/src/main/java/org/approvej/ApprovalResult.java
+++ b/modules/core/src/main/java/org/approvej/ApprovalResult.java
@@ -1,6 +1,9 @@
 package org.approvej;
 
+import org.jspecify.annotations.NullMarked;
+
 /** Interface for results of approvals. */
+@NullMarked
 public interface ApprovalResult {
 
   /**

--- a/modules/core/src/main/java/org/approvej/ApprovalTest.java
+++ b/modules/core/src/main/java/org/approvej/ApprovalTest.java
@@ -4,6 +4,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
@@ -17,4 +18,5 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(DanglingApprovalExtension.class)
+@NullMarked
 public @interface ApprovalTest {}

--- a/modules/core/src/main/java/org/approvej/approve/Approver.java
+++ b/modules/core/src/main/java/org/approvej/approve/Approver.java
@@ -3,9 +3,11 @@ package org.approvej.approve;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.approvej.ApprovalResult;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * A {@link Consumer} that approved a printed value and (optionally) stores the value in some
  * fashion if approved for a later execution.
  */
+@NullMarked
 public interface Approver extends Function<String, ApprovalResult> {}

--- a/modules/core/src/main/java/org/approvej/approve/FileApprovalResult.java
+++ b/modules/core/src/main/java/org/approvej/approve/FileApprovalResult.java
@@ -1,6 +1,7 @@
 package org.approvej.approve;
 
 import org.approvej.ApprovalResult;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * {@link ApprovalResult} for files.
@@ -10,6 +11,7 @@ import org.approvej.ApprovalResult;
  * @param pathProvider the {@link PathProvider} providing the paths to the received an approved
  *     files
  */
+@NullMarked
 public record FileApprovalResult(
     String previouslyApproved, String received, PathProvider pathProvider)
     implements ApprovalResult {}

--- a/modules/core/src/main/java/org/approvej/approve/InplaceApprovalResult.java
+++ b/modules/core/src/main/java/org/approvej/approve/InplaceApprovalResult.java
@@ -1,6 +1,7 @@
 package org.approvej.approve;
 
 import org.approvej.ApprovalResult;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * A simple {@link ApprovalResult}, e.g. for an {@link InplaceApprover}.
@@ -8,5 +9,6 @@ import org.approvej.ApprovalResult;
  * @param previouslyApproved the value that was previously approved
  * @param received the value that was received for approval
  */
+@NullMarked
 public record InplaceApprovalResult(String previouslyApproved, String received)
     implements ApprovalResult {}

--- a/modules/core/src/main/java/org/approvej/configuration/ConfigurationError.java
+++ b/modules/core/src/main/java/org/approvej/configuration/ConfigurationError.java
@@ -1,10 +1,14 @@
 package org.approvej.configuration;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
 /**
  * An error that occurs when there is an issue with loading the configuration.
  *
  * @see Configuration
  */
+@NullMarked
 public class ConfigurationError extends RuntimeException {
 
   /**
@@ -13,7 +17,7 @@ public class ConfigurationError extends RuntimeException {
    * @param message a message describing the error
    * @param cause the cause of the error
    */
-  public ConfigurationError(String message, Throwable cause) {
+  public ConfigurationError(String message, @Nullable Throwable cause) {
     super(message, cause);
   }
 }

--- a/modules/core/src/main/java/org/approvej/print/PrintFormat.java
+++ b/modules/core/src/main/java/org/approvej/print/PrintFormat.java
@@ -1,11 +1,14 @@
 package org.approvej.print;
 
+import org.jspecify.annotations.NullMarked;
+
 /**
  * A format to print values of type T, as defined by a {@link Printer} and a suggested {@link
  * #filenameExtension()}.
  *
  * @param <T> the type of the object to print
  */
+@NullMarked
 public interface PrintFormat<T> {
 
   /** The default filename extension for files that the printed value is written to. */

--- a/modules/core/src/main/java/org/approvej/print/Printer.java
+++ b/modules/core/src/main/java/org/approvej/print/Printer.java
@@ -1,10 +1,12 @@
 package org.approvej.print;
 
 import java.util.function.Function;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * A {@link Function} that converts an object to a {@link String}.
  *
  * @param <T> the type of the object to print
  */
+@NullMarked
 public interface Printer<T> extends Function<T, String> {}

--- a/modules/core/src/main/java/org/approvej/print/PropertyOrdering.java
+++ b/modules/core/src/main/java/org/approvej/print/PropertyOrdering.java
@@ -10,6 +10,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Utility for deterministic property ordering during serialization.
@@ -17,6 +18,7 @@ import java.util.function.Function;
  * <p>Field-backed properties are ordered first in their declaration order, followed by any
  * additional properties (e.g. from getters) in alphabetical order.
  */
+@NullMarked
 public final class PropertyOrdering {
 
   private PropertyOrdering() {}

--- a/modules/core/src/main/java/org/approvej/review/ReviewResult.java
+++ b/modules/core/src/main/java/org/approvej/review/ReviewResult.java
@@ -1,6 +1,9 @@
 package org.approvej.review;
 
+import org.jspecify.annotations.NullMarked;
+
 /** Interface for results of reviews. */
+@NullMarked
 public interface ReviewResult {
 
   /**

--- a/modules/core/src/main/java/org/approvej/review/ReviewResultRecord.java
+++ b/modules/core/src/main/java/org/approvej/review/ReviewResultRecord.java
@@ -1,9 +1,12 @@
 package org.approvej.review;
 
+import org.jspecify.annotations.NullMarked;
+
 /**
  * Result class for {@link Reviewer}s.
  *
  * @param needsReapproval indicates if the result should be reapproved after the review (e.g.
  *     because the approval file was modified)
  */
+@NullMarked
 public record ReviewResultRecord(boolean needsReapproval) implements ReviewResult {}

--- a/modules/core/src/main/java/org/approvej/review/Reviewer.java
+++ b/modules/core/src/main/java/org/approvej/review/Reviewer.java
@@ -3,6 +3,7 @@ package org.approvej.review;
 import java.nio.file.Path;
 import java.util.function.Function;
 import org.approvej.approve.PathProvider;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Interface for triggering a review by the user.
@@ -10,6 +11,7 @@ import org.approvej.approve.PathProvider;
  * <p>This usually means that a diff/merge tool is opened, which presents the difference between the
  * received and the previously approved value to users in case they differ.
  */
+@NullMarked
 public interface Reviewer extends Function<PathProvider, ReviewResult> {
 
   /** Placeholder in commands that is replaced with the received file path. */

--- a/modules/core/src/main/java/org/approvej/scrub/DateTimeScrubber.java
+++ b/modules/core/src/main/java/org/approvej/scrub/DateTimeScrubber.java
@@ -1,11 +1,13 @@
 package org.approvej.scrub;
 
 import java.time.format.DateTimeFormatter;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Scrubs a {@link String} of date/time strings described by a {@link DateTimeFormatter} pattern
  * like "yyyy-MM-dd" for local dates using the wrapped {@link StringScrubber}.
  */
+@NullMarked
 public interface DateTimeScrubber extends Scrubber<DateTimeScrubber, String, String> {
 
   /**

--- a/modules/core/src/main/java/org/approvej/scrub/FieldScrubber.java
+++ b/modules/core/src/main/java/org/approvej/scrub/FieldScrubber.java
@@ -1,5 +1,7 @@
 package org.approvej.scrub;
 
+import org.jspecify.annotations.NullMarked;
+
 /**
  * Generic {@link Scrubber} to set the value of a certain field via reflection.
  *
@@ -8,4 +10,5 @@ package org.approvej.scrub;
  *
  * @param <T> the type of value to scrub
  */
+@NullMarked
 public interface FieldScrubber<T> extends Scrubber<FieldScrubber<T>, T, Object> {}

--- a/modules/core/src/main/java/org/approvej/scrub/RelativeDateReplacement.java
+++ b/modules/core/src/main/java/org/approvej/scrub/RelativeDateReplacement.java
@@ -1,11 +1,13 @@
 package org.approvej.scrub;
 
 import java.time.format.DateTimeFormatter;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Replaces each match of the given dateTimePattern (as defined by {@link DateTimeFormatter}) with a
  * relative description, like {@code [today]}, {@code [yesterday]}, {@code [13 days from now]}.
  */
+@NullMarked
 public interface RelativeDateReplacement extends Replacement<String> {
 
   /**

--- a/modules/core/src/main/java/org/approvej/scrub/RelativeDateTimeReplacement.java
+++ b/modules/core/src/main/java/org/approvej/scrub/RelativeDateTimeReplacement.java
@@ -2,6 +2,7 @@ package org.approvej.scrub;
 
 import java.time.Duration;
 import java.time.format.DateTimeFormatter;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Replaces each match of the given dateTimePattern (as defined by {@link DateTimeFormatter}) with a
@@ -10,6 +11,7 @@ import java.time.format.DateTimeFormatter;
  * <p>To avoid flaky results, the value is always rounded to a certain {@link Duration} (e.g. 1s).
  * This duration can be adjusted via {@link #roundedTo(Duration)}.
  */
+@NullMarked
 public interface RelativeDateTimeReplacement extends Replacement<String> {
 
   /**

--- a/modules/core/src/main/java/org/approvej/scrub/Replacement.java
+++ b/modules/core/src/main/java/org/approvej/scrub/Replacement.java
@@ -1,6 +1,7 @@
 package org.approvej.scrub;
 
 import java.util.function.BiFunction;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -8,6 +9,7 @@ import org.jspecify.annotations.Nullable;
  *
  * @param <R> the type of the replaced value
  */
+@NullMarked
 public interface Replacement<R> extends BiFunction<R, Integer, R> {
 
   /**

--- a/modules/core/src/main/java/org/approvej/scrub/Scrubber.java
+++ b/modules/core/src/main/java/org/approvej/scrub/Scrubber.java
@@ -1,6 +1,7 @@
 package org.approvej.scrub;
 
 import java.util.function.UnaryOperator;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * An {@link UnaryOperator} that scrubs certain information from a value. This might be useful
@@ -10,6 +11,7 @@ import java.util.function.UnaryOperator;
  * @param <T> the type of value to scrub
  * @param <R> the type of the replacement
  */
+@NullMarked
 public interface Scrubber<I extends Scrubber<I, T, R>, T, R> extends UnaryOperator<T> {
 
   /**

--- a/modules/core/src/main/java/org/approvej/scrub/ScrubbingError.java
+++ b/modules/core/src/main/java/org/approvej/scrub/ScrubbingError.java
@@ -1,6 +1,9 @@
 package org.approvej.scrub;
 
+import org.jspecify.annotations.NullMarked;
+
 /** Exception thrown when scrubbing fails. */
+@NullMarked
 public class ScrubbingError extends RuntimeException {
 
   /**

--- a/modules/core/src/main/java/org/approvej/scrub/StringScrubber.java
+++ b/modules/core/src/main/java/org/approvej/scrub/StringScrubber.java
@@ -1,9 +1,11 @@
 package org.approvej.scrub;
 
 import java.util.function.Function;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Scrubs a {@link String} by replacing all occurrences of a pattern by applying the given
  * replacement {@link Function} for each finding.
  */
+@NullMarked
 public interface StringScrubber extends Scrubber<StringScrubber, String, String> {}

--- a/modules/image/src/main/java/org/approvej/image/ImageApprovalResult.java
+++ b/modules/image/src/main/java/org/approvej/image/ImageApprovalResult.java
@@ -1,6 +1,9 @@
 package org.approvej.image;
 
+import org.jspecify.annotations.NullMarked;
+
 /** Result of evaluating an image approval. */
+@NullMarked
 public interface ImageApprovalResult {
 
   /**

--- a/modules/image/src/main/java/org/approvej/image/approve/ImageApprover.java
+++ b/modules/image/src/main/java/org/approvej/image/approve/ImageApprover.java
@@ -3,6 +3,8 @@ package org.approvej.image.approve;
 import java.awt.image.BufferedImage;
 import java.util.function.Function;
 import org.approvej.image.ImageApprovalResult;
+import org.jspecify.annotations.NullMarked;
 
 /** A {@link Function} that evaluates a received image against an approved baseline. */
+@NullMarked
 public interface ImageApprover extends Function<BufferedImage, ImageApprovalResult> {}

--- a/modules/image/src/main/java/org/approvej/image/approve/ImageFileApprovalResult.java
+++ b/modules/image/src/main/java/org/approvej/image/approve/ImageFileApprovalResult.java
@@ -4,6 +4,7 @@ import org.approvej.approve.PathProvider;
 import org.approvej.image.ImageApprovalError;
 import org.approvej.image.ImageApprovalResult;
 import org.approvej.image.compare.ImageComparisonResult;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * {@link ImageApprovalResult} for image files.
@@ -12,6 +13,7 @@ import org.approvej.image.compare.ImageComparisonResult;
  * @param pathProvider the {@link PathProvider} providing the paths to the received and approved
  *     files
  */
+@NullMarked
 public record ImageFileApprovalResult(
     ImageComparisonResult comparisonResult, PathProvider pathProvider)
     implements ImageApprovalResult {

--- a/modules/json-jackson/src/main/java/org/approvej/json/jackson/DeterministicPropertyOrder.java
+++ b/modules/json-jackson/src/main/java/org/approvej/json/jackson/DeterministicPropertyOrder.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
 import java.util.List;
 import org.approvej.print.PropertyOrdering;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * A {@link BeanSerializerModifier} that ensures deterministic property ordering.
@@ -13,6 +14,7 @@ import org.approvej.print.PropertyOrdering;
  * <p>Field-backed properties are serialized first in their declaration order, followed by any
  * additional properties (e.g. from getters) in alphabetical order.
  */
+@NullMarked
 final class DeterministicPropertyOrder extends BeanSerializerModifier {
 
   @Override

--- a/modules/json-jackson/src/main/java/org/approvej/json/jackson/JsonPrinterException.java
+++ b/modules/json-jackson/src/main/java/org/approvej/json/jackson/JsonPrinterException.java
@@ -1,6 +1,10 @@
 package org.approvej.json.jackson;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
 /** Exception thrown when pretty printing a value as JSON fails. */
+@NullMarked
 class JsonPrinterException extends RuntimeException {
 
   /**
@@ -9,7 +13,7 @@ class JsonPrinterException extends RuntimeException {
    * @param value the value that failed to be pretty printed
    * @param cause the cause of the failure
    */
-  public JsonPrinterException(Object value, Throwable cause) {
+  public JsonPrinterException(Object value, @Nullable Throwable cause) {
     super("Failed to pretty print %s".formatted(value), cause);
   }
 }

--- a/modules/json-jackson3/src/main/java/org/approvej/json/jackson3/DeterministicPropertyOrder.java
+++ b/modules/json-jackson3/src/main/java/org/approvej/json/jackson3/DeterministicPropertyOrder.java
@@ -2,6 +2,7 @@ package org.approvej.json.jackson3;
 
 import java.util.List;
 import org.approvej.print.PropertyOrdering;
+import org.jspecify.annotations.NullMarked;
 import tools.jackson.databind.BeanDescription;
 import tools.jackson.databind.SerializationConfig;
 import tools.jackson.databind.ser.BeanPropertyWriter;
@@ -13,6 +14,7 @@ import tools.jackson.databind.ser.ValueSerializerModifier;
  * <p>Field-backed properties are serialized first in their declaration order, followed by any
  * additional properties (e.g. from getters) in alphabetical order.
  */
+@NullMarked
 final class DeterministicPropertyOrder extends ValueSerializerModifier {
 
   @Override

--- a/modules/json-jackson3/src/main/java/org/approvej/json/jackson3/JsonPrinterException.java
+++ b/modules/json-jackson3/src/main/java/org/approvej/json/jackson3/JsonPrinterException.java
@@ -1,6 +1,10 @@
 package org.approvej.json.jackson3;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
 /** Exception thrown when pretty printing a value as JSON fails. */
+@NullMarked
 class JsonPrinterException extends RuntimeException {
 
   /**
@@ -9,7 +13,7 @@ class JsonPrinterException extends RuntimeException {
    * @param value the value that failed to be pretty printed
    * @param cause the cause of the failure
    */
-  public JsonPrinterException(Object value, Throwable cause) {
+  public JsonPrinterException(Object value, @Nullable Throwable cause) {
     super("Failed to pretty print %s".formatted(value), cause);
   }
 }

--- a/modules/yaml-jackson/src/main/java/org/approvej/yaml/jackson/DeterministicPropertyOrder.java
+++ b/modules/yaml-jackson/src/main/java/org/approvej/yaml/jackson/DeterministicPropertyOrder.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
 import java.util.List;
 import org.approvej.print.PropertyOrdering;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * A {@link BeanSerializerModifier} that ensures deterministic property ordering.
@@ -13,6 +14,7 @@ import org.approvej.print.PropertyOrdering;
  * <p>Field-backed properties are serialized first in their declaration order, followed by any
  * additional properties (e.g. from getters) in alphabetical order.
  */
+@NullMarked
 final class DeterministicPropertyOrder extends BeanSerializerModifier {
 
   @Override

--- a/modules/yaml-jackson/src/main/java/org/approvej/yaml/jackson/YamlPrinterException.java
+++ b/modules/yaml-jackson/src/main/java/org/approvej/yaml/jackson/YamlPrinterException.java
@@ -1,8 +1,11 @@
 package org.approvej.yaml.jackson;
 
 import com.fasterxml.jackson.core.JacksonException;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /** Exception thrown when pretty printing a value as YAML fails. */
+@NullMarked
 public class YamlPrinterException extends RuntimeException {
 
   /**
@@ -11,7 +14,7 @@ public class YamlPrinterException extends RuntimeException {
    * @param value the value that failed to be pretty printed
    * @param cause the cause of the failure
    */
-  public YamlPrinterException(Object value, JacksonException cause) {
+  public YamlPrinterException(Object value, @Nullable JacksonException cause) {
     super("Failed to print %s".formatted(value), cause);
   }
 }

--- a/modules/yaml-jackson3/src/main/java/org/approvej/yaml/jackson3/DeterministicPropertyOrder.java
+++ b/modules/yaml-jackson3/src/main/java/org/approvej/yaml/jackson3/DeterministicPropertyOrder.java
@@ -2,6 +2,7 @@ package org.approvej.yaml.jackson3;
 
 import java.util.List;
 import org.approvej.print.PropertyOrdering;
+import org.jspecify.annotations.NullMarked;
 import tools.jackson.databind.BeanDescription;
 import tools.jackson.databind.SerializationConfig;
 import tools.jackson.databind.ser.BeanPropertyWriter;
@@ -13,6 +14,7 @@ import tools.jackson.databind.ser.ValueSerializerModifier;
  * <p>Field-backed properties are serialized first in their declaration order, followed by any
  * additional properties (e.g. from getters) in alphabetical order.
  */
+@NullMarked
 final class DeterministicPropertyOrder extends ValueSerializerModifier {
 
   @Override

--- a/modules/yaml-jackson3/src/main/java/org/approvej/yaml/jackson3/YamlPrinterException.java
+++ b/modules/yaml-jackson3/src/main/java/org/approvej/yaml/jackson3/YamlPrinterException.java
@@ -1,8 +1,11 @@
 package org.approvej.yaml.jackson3;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import tools.jackson.core.JacksonException;
 
 /** Exception thrown when pretty printing a value as YAML fails. */
+@NullMarked
 public class YamlPrinterException extends RuntimeException {
 
   /**
@@ -11,7 +14,7 @@ public class YamlPrinterException extends RuntimeException {
    * @param value the value that failed to be pretty printed
    * @param cause the cause of the failure
    */
-  public YamlPrinterException(Object value, JacksonException cause) {
+  public YamlPrinterException(Object value, @Nullable JacksonException cause) {
     super("Failed to print %s".formatted(value), cause);
   }
 }


### PR DESCRIPTION
Adds `@NullMarked` (JSpecify) to public API classes across the library modules that were still missing it, so null-safety is explicit and consistent with the rest of the codebase.

## Scope

Pure annotation additions — no behavioral changes. Affected classes span:

- **core** — `ApprovalResult`, `ApprovalTest`, `Approver`, `FileApprovalResult`, `InplaceApprovalResult`, `ConfigurationError`, print/`PrintFormat`/`Printer`/`PropertyOrdering`, review/`ReviewResult`/`ReviewResultRecord`/`Reviewer`, scrub/* (`DateTimeScrubber`, `FieldScrubber`, `Replacement`s, `Scrubber`, `ScrubbingError`, `StringScrubber`)
- **image** — `ImageApprovalResult`, `ImageApprover`, `ImageFileApprovalResult`
- **json-jackson / json-jackson3** — `DeterministicPropertyOrder`, `JsonPrinterException`
- **yaml-jackson / yaml-jackson3** — `DeterministicPropertyOrder`, `YamlPrinterException`

31 files, annotations only.

## Notes

Split out of the Kotest work (#162) to keep that PR focused; this stands on its own.

## Verification

- `spotlessCheck` clean.
- Affected modules compile.